### PR TITLE
[v2.0034] adjust building CPS for sugar lumps

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2695,6 +2695,7 @@ CM.Sim.InitData = function() {
 		// Below is needed for above eval!
 		you.baseCps = me.baseCps;
 		you.name = me.name;
+		you.level = me.level;
 	}
 
 	// Upgrades

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2572,8 +2572,8 @@ CM.DelayInit = function() {
 CM.ConfigDefault = {BotBar: 1, TimerBar: 1, TimerBarPos: 0, BuildColor: 1, BulkBuildColor: 0, UpBarColor: 1, CalcWrink: 1, CPSMode: 1, AvgCPSHist: 2, AvgClicksHist: 2, ToolWarnCautBon: 0, Flash: 1, Sound: 1,  Volume: 100, GCSoundURL: 'http://freesound.org/data/previews/66/66717_931655-lq.mp3', SeaSoundURL: 'http://www.freesound.org/data/previews/121/121099_2193266-lq.mp3', GCTimer: 1, Title: 1, Favicon: 1, Tooltip: 1, TooltipAmor: 0, ToolWarnCaut: 1, ToolWarnCautPos: 1, ToolWrink: 1, Stats: 1, UpStats: 1, TimeFormat: 0, SayTime: 1, Scale: 2, StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1}, Colors : {Blue: '#4bb8f0', Green: '#00ff00', Yellow: '#ffff00', Orange: '#ff7f00', Red: '#ff0000', Purple: '#ff00ff', Gray: '#b3b3b3', Pink: '#ff1493', Brown: '#8b4513'}};
 CM.ConfigPrefix = 'CMConfig';
 
-CM.VersionMajor = '2.002';
-CM.VersionMinor = '2';
+CM.VersionMajor = '2.0034';
+CM.VersionMinor = '1';
 
 /*******
  * Sim *
@@ -2774,7 +2774,11 @@ CM.Sim.CalculateGains = function() {
 
 	for (var i in CM.Sim.Objects) {
 		var me = CM.Sim.Objects[i];
-		CM.Sim.cookiesPs += me.amount * (typeof(me.cps) == 'function' ? me.cps(me) : me.cps);
+		
+		var cpsThisObject = me.amount * (typeof(me.cps) == 'function' ? me.cps(me) : me.cps);
+		cpsThisObject *= (1 + me.level * 0.01);
+
+		CM.Sim.cookiesPs += cpsThisObject;
 	}
 
 	if (CM.Sim.Has('"egg"')) CM.Sim.cookiesPs += 9; // "egg"

--- a/src/Main.js
+++ b/src/Main.js
@@ -203,6 +203,6 @@ CM.DelayInit = function() {
 CM.ConfigDefault = {BotBar: 1, TimerBar: 1, TimerBarPos: 0, BuildColor: 1, BulkBuildColor: 0, UpBarColor: 1, CalcWrink: 1, CPSMode: 1, AvgCPSHist: 2, AvgClicksHist: 2, ToolWarnCautBon: 0, Flash: 1, Sound: 1,  Volume: 100, GCSoundURL: 'http://freesound.org/data/previews/66/66717_931655-lq.mp3', SeaSoundURL: 'http://www.freesound.org/data/previews/121/121099_2193266-lq.mp3', GCTimer: 1, Title: 1, Favicon: 1, Tooltip: 1, TooltipAmor: 0, ToolWarnCaut: 1, ToolWarnCautPos: 1, ToolWrink: 1, Stats: 1, UpStats: 1, TimeFormat: 0, SayTime: 1, Scale: 2, StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1}, Colors : {Blue: '#4bb8f0', Green: '#00ff00', Yellow: '#ffff00', Orange: '#ff7f00', Red: '#ff0000', Purple: '#ff00ff', Gray: '#b3b3b3', Pink: '#ff1493', Brown: '#8b4513'}};
 CM.ConfigPrefix = 'CMConfig';
 
-CM.VersionMajor = '2.002';
-CM.VersionMinor = '2';
+CM.VersionMajor = '2.0034';
+CM.VersionMinor = '1';
 

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -197,7 +197,11 @@ CM.Sim.CalculateGains = function() {
 
 	for (var i in CM.Sim.Objects) {
 		var me = CM.Sim.Objects[i];
-		CM.Sim.cookiesPs += me.amount * (typeof(me.cps) == 'function' ? me.cps(me) : me.cps);
+		
+		var cpsThisObject = me.amount * (typeof(me.cps) == 'function' ? me.cps(me) : me.cps);
+		cpsThisObject *= (1 + me.level * 0.01);
+
+		CM.Sim.cookiesPs += cpsThisObject;
 	}
 
 	if (CM.Sim.Has('"egg"')) CM.Sim.cookiesPs += 9; // "egg"

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -118,6 +118,7 @@ CM.Sim.InitData = function() {
 		// Below is needed for above eval!
 		you.baseCps = me.baseCps;
 		you.name = me.name;
+		you.level = me.level;
 	}
 
 	// Upgrades


### PR DESCRIPTION
caveats:
- can't guarantee this multiplier is applied in the right order with respect to other multipliers, but it looked like it from code inspection and it doesn't seem to be wildly wrong;
- this only accounts for sugar lumps.  in particular, it appears that v2.0034 also introduces the concept of gods which provide CPS multipliers for buildings, which are not accounted for.

fixes #119.