### PR TITLE
Provide ETA on Grimoire spell casting (Issue #136)

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2029,25 +2029,29 @@ CM.Disp.ToggleToolWarnCautPos = function() {
 }
 
 CM.Disp.AddTooltipBuild = function() {
-	CM.Disp.TooltipBuildBack = [];
 	for (var i in Game.Objects) {
 		var me = Game.Objects[i];
 		if (l('product' + me.id).onmouseover != null) {
-			CM.Disp.TooltipBuildBack[i] = l('product' + me.id).onmouseover;
 			eval('l(\'product\' + me.id).onmouseover = function() {Game.tooltip.dynamic = 1; Game.tooltip.draw(this, function() {return CM.Disp.Tooltip(\'b\', \'' + i + '\');}, \'store\'); Game.tooltip.wobble();}');
 		}
 	}
 }
 
 CM.Disp.AddTooltipUpgrade = function() {
-	CM.Disp.TooltipUpgradeBack = [];
 	for (var i in Game.UpgradesInStore) {
-		var me = Game.UpgradesInStore[i];
 		if (l('upgrade' + i).onmouseover != null) {
-			CM.Disp.TooltipUpgradeBack[i] = l('upgrade' + i).onmouseover;
 			eval('l(\'upgrade\' + i).onmouseover = function() {if (!Game.mouseDown) {Game.setOnCrate(this); Game.tooltip.dynamic = 1; Game.tooltip.draw(this, function() {return CM.Disp.Tooltip(\'u\', \'' + i + '\');}, \'store\'); Game.tooltip.wobble();}}');
 		}
 	}
+}
+
+CM.Disp.AddTooltipSpell = function() {
+  var grimoire = Game.Objects["Wizard tower"].minigame;
+  for (var i in grimoire.spellsById) {
+    if (l('grimoireSpell' + i).onmouseover != null) {
+      eval('l(\'grimoireSpell\' + i).onmouseover = function() {Game.tooltip.dynamic = 1; Game.tooltip.draw(this, function() {return CM.Disp.Tooltip(\'s\', \'' + i + '\');}, \'this\'); Game.tooltip.wobble();}');
+    }
+  }
 }
 
 CM.Disp.Tooltip = function(type, name) {
@@ -2084,10 +2088,43 @@ CM.Disp.Tooltip = function(type, name) {
 			}
 		}
 	}
-	else { // Upgrades
+	else if (type == 'u') { // Upgrades
 		if (!Game.UpgradesInStore[name]) return '';
 		l('tooltip').innerHTML = Game.crate(Game.UpgradesInStore[name], 'store', undefined, undefined, 1)();
 	}
+  else if (type == 's') { // Spells
+    var grimoire = Game.Objects["Wizard tower"].minigame;
+    var spell = grimoire.spellsById[name];
+    var cost = grimoire.getSpellCost(spell);
+    var content = grimoire.spellTooltip(name)();
+
+    function formatDuration(seconds) {
+      var minutes = Math.floor(seconds / 60);
+
+      if (minutes > 0) {
+        return minutes + " minutes, " + Math.floor(seconds - minutes * 60) + " seconds";
+      } else  {
+        return Math.floor(seconds) + " seconds";
+      }
+    }
+
+    if (cost <= grimoire.magicM && cost > grimoire.magic) {
+      content += "Can afford in: " + formatDuration(CM.Sim.Grimoire.estimateTimeElapsed(grimoire.magic, cost, grimoire.magicM));
+      content += "<br>";
+    }
+
+    if (cost <= grimoire.magic) {
+      content += "Recovery in: " + formatDuration(CM.Sim.Grimoire.estimateTimeElapsed(grimoire.magic - cost, grimoire.magic, grimoire.magicM));
+      content += "<br>";
+    
+      if (cost * 2 > grimoire.magic) {
+        content += "Afford again in: " + formatDuration(CM.Sim.Grimoire.estimateTimeElapsed(grimoire.magic - cost, cost, grimoire.magicM));
+        content += "<br>";
+      }
+    }
+
+    return content;
+  }
 	
 	var area = document.createElement('div');
 	area.id = 'CMTooltipArea';
@@ -2567,7 +2604,8 @@ CM.DelayInit = function() {
 	CM.Disp.CreateTooltip('ResetTooltipPlaceholder', 'The bonus income you would get from new prestige levels at 100% of its potential and from reset achievements if you have the same buildings/upgrades after reset', '340px');
 	CM.Disp.CreateTooltip('ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers, selling all buildings with Earth Shatterer aura, and then buying Chocolate egg', '300px');
 	CM.Disp.CreateTooltipWarnCaut();
-	CM.Disp.AddTooltipBuild();
+  CM.Disp.AddTooltipBuild();
+	CM.Disp.AddTooltipSpell();
 	CM.Disp.AddWrinklerAreaDetect();
 	CM.Cache.InitCookiesDiff();
 	CM.ReplaceNative();
@@ -3150,6 +3188,86 @@ CM.Sim.ResetBonus = function(possiblePresMax) {
 	return (CM.Sim.cookiesPs - curCPS);
 }
 
+// Grimoire Estimation
+
+CM.Sim.Grimoire = (function() {
+  var fps = 30;
+
+  function calcMagicPerSecond(current, maxMagic) {
+    return Math.max(0.002,Math.pow(current/Math.max(maxMagic,100),0.5))*0.002*fps;
+  }
+
+  /*
+
+  let z = Math.max(maxMagic, 100)
+
+  m' = k * sqrt(m / z) = k * sqrt(m) / sqrt(z) = k * sqrt(m) ; constant k absorbs other constant sqrt(z)
+  dm/dt = k * sqrt(m)
+  dm/sqrt(m) = k * dt ; separate variables
+  2 * sqrt(m) = kt + c ; integrate. now we have two unknown constants
+
+  solve m:
+  m(t) = ((kt + c) / 2)**2 = (kt + c)**2 / 4
+
+  solve t:
+  t(m) = (2 * sqrt(m) - c) / k
+
+  find k: let m = 1, maxMagic = 100
+  m'(m) = 0.006 = k * sqrt(1)
+  k = 0.006
+  OR
+  k = 0.06 / sqrt(z)
+
+  find c:
+  run simulation for how long it takes to go from m=0 to m=max
+
+  for maxMagic = 100, c is -0.004
+
+  .:. for maxMagic = 100, t(m) = (2 * sqrt(m) + 0.004) / 0.006
+
+  .:. general solution, t(m) = (2 * sqrt(m) - c) / (0.06 / sqrt(z))
+                             = 16.6667 * (2 * sqrt(m) - c) * sqrt(z)
+
+  */
+
+  var C_CACHE = {};
+  function findC(maxMagic) {
+    if (C_CACHE[maxMagic] !== undefined) {
+      return C_CACHE[maxMagic];
+    }
+
+    var m = 0;
+    var t = 0;
+
+    while (m < maxMagic) {
+      m += calcMagicPerSecond(m, maxMagic);
+      t += 1;
+    }
+
+    var z = Math.max(maxMagic, 100);
+    var k = 0.06 / Math.pow(z, 0.5);
+    var c = 2 * Math.pow(maxMagic, 0.5) - k * t;
+
+    C_CACHE[maxMagic] = c;
+
+    return c;
+  }
+
+  function timeFromZeroToM(m, maxMagic) {
+    var z = Math.max(100, maxMagic);
+    var c = findC(z);
+    return 16.6667 * (2 * Math.pow(m, 0.5) - c) * Math.pow(z, 0.5);
+  }
+
+  // this will be inaccurate if m0 = 0.
+  function timeElapsed(m0, m1, maxMagic) {
+    return timeFromZeroToM(m1, maxMagic) - timeFromZeroToM(m0, maxMagic);
+  }
+
+  return {
+    estimateTimeElapsed: timeElapsed
+  }
+})();
 /**********
  * Footer *
  **********/

--- a/src/Main.js
+++ b/src/Main.js
@@ -184,7 +184,8 @@ CM.DelayInit = function() {
 	CM.Disp.CreateTooltip('ResetTooltipPlaceholder', 'The bonus income you would get from new prestige levels at 100% of its potential and from reset achievements if you have the same buildings/upgrades after reset', '340px');
 	CM.Disp.CreateTooltip('ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers, selling all buildings with Earth Shatterer aura, and then buying Chocolate egg', '300px');
 	CM.Disp.CreateTooltipWarnCaut();
-	CM.Disp.AddTooltipBuild();
+  CM.Disp.AddTooltipBuild();
+	CM.Disp.AddTooltipSpell();
 	CM.Disp.AddWrinklerAreaDetect();
 	CM.Cache.InitCookiesDiff();
 	CM.ReplaceNative();

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -559,3 +559,83 @@ CM.Sim.ResetBonus = function(possiblePresMax) {
 	return (CM.Sim.cookiesPs - curCPS);
 }
 
+// Grimoire Estimation
+
+CM.Sim.Grimoire = (function() {
+  var fps = 30;
+
+  function calcMagicPerSecond(current, maxMagic) {
+    return Math.max(0.002,Math.pow(current/Math.max(maxMagic,100),0.5))*0.002*fps;
+  }
+
+  /*
+
+  let z = Math.max(maxMagic, 100)
+
+  m' = k * sqrt(m / z) = k * sqrt(m) / sqrt(z) = k * sqrt(m) ; constant k absorbs other constant sqrt(z)
+  dm/dt = k * sqrt(m)
+  dm/sqrt(m) = k * dt ; separate variables
+  2 * sqrt(m) = kt + c ; integrate. now we have two unknown constants
+
+  solve m:
+  m(t) = ((kt + c) / 2)**2 = (kt + c)**2 / 4
+
+  solve t:
+  t(m) = (2 * sqrt(m) - c) / k
+
+  find k: let m = 1, maxMagic = 100
+  m'(m) = 0.006 = k * sqrt(1)
+  k = 0.006
+  OR
+  k = 0.06 / sqrt(z)
+
+  find c:
+  run simulation for how long it takes to go from m=0 to m=max
+
+  for maxMagic = 100, c is -0.004
+
+  .:. for maxMagic = 100, t(m) = (2 * sqrt(m) + 0.004) / 0.006
+
+  .:. general solution, t(m) = (2 * sqrt(m) - c) / (0.06 / sqrt(z))
+                             = 16.6667 * (2 * sqrt(m) - c) * sqrt(z)
+
+  */
+
+  var C_CACHE = {};
+  function findC(maxMagic) {
+    if (C_CACHE[maxMagic] !== undefined) {
+      return C_CACHE[maxMagic];
+    }
+
+    var m = 0;
+    var t = 0;
+
+    while (m < maxMagic) {
+      m += calcMagicPerSecond(m, maxMagic);
+      t += 1;
+    }
+
+    var z = Math.max(maxMagic, 100);
+    var k = 0.06 / Math.pow(z, 0.5);
+    var c = 2 * Math.pow(maxMagic, 0.5) - k * t;
+
+    C_CACHE[maxMagic] = c;
+
+    return c;
+  }
+
+  function timeFromZeroToM(m, maxMagic) {
+    var z = Math.max(100, maxMagic);
+    var c = findC(z);
+    return 16.6667 * (2 * Math.pow(m, 0.5) - c) * Math.pow(z, 0.5);
+  }
+
+  // this will be inaccurate if m0 = 0.
+  function timeElapsed(m0, m1, maxMagic) {
+    return timeFromZeroToM(m1, maxMagic) - timeFromZeroToM(m0, maxMagic);
+  }
+
+  return {
+    estimateTimeElapsed: timeElapsed
+  }
+})();


### PR DESCRIPTION
Hovering over a spell that can't be afforded yet will display an ETA for when it can be afforded.

If a spell can be afforded, "Recovery in" relays how long until you will be back to the same mana, if you cast the spell now.

If a spell can be afforded once, but not twice, "Afford again in" relays how long until you can cast the spell again, if you were to cast it first now.