### PR TITLE
Fix userscripts for GreaseMonkey 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ If you'd rather use the addon as a script via per example *Greasemonkey* or *Tam
 // ==/UserScript==
 
 (function() {
+    var game = unsafeWindow.Game;
     var checkReady = setInterval(function() {
-        if (typeof Game.ready !== 'undefined' && Game.ready) {
-            Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonster.js');
+        if (typeof game.ready !== 'undefined' && game.ready) {
+            game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonster.js');
             clearInterval(checkReady);
         }
     }, 1000);
-})();
+})();;
 ```
 If you are using the beta, use this instead:
 
@@ -102,13 +103,14 @@ If you are using the beta, use this instead:
 // ==/UserScript==
 
 (function() {
+    var game = unsafeWindow.Game;
     var checkReady = setInterval(function() {
-        if (typeof Game.ready !== 'undefined' && Game.ready) {
-            Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
+        if (typeof game.ready !== 'undefined' && game.ready) {
+            game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
             clearInterval(checkReady);
         }
     }, 1000);
-})();
+})();;
 ```
 
 # Bugs and suggestions


### PR DESCRIPTION
In GreaseMonkey 4, userscripts don't share the page's window object. Instead, it's accessed through unsafeWindow.