### PR TITLE
Add TLS to HTTP links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Copy this code and save it as a bookmark. Paste it in the URL section. To activa
 
 ```javascript
 javascript: (function () {
-	Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonster.js');
+	Game.LoadMod('https://aktanusa.github.io/CookieMonster/CookieMonster.js');
 }());
 ```
 
@@ -64,7 +64,7 @@ For beta, use the following instead:
 
 ```javascript
 javascript: (function () {
-	Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
+	Game.LoadMod('https://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
 }());
 ```
 
@@ -84,7 +84,7 @@ If you'd rather use the addon as a script via per example *Greasemonkey* or *Tam
 (function() {
     var checkReady = setInterval(function() {
         if (typeof Game.ready !== 'undefined' && Game.ready) {
-            Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonster.js');
+            Game.LoadMod('https://aktanusa.github.io/CookieMonster/CookieMonster.js');
             clearInterval(checkReady);
         }
     }, 1000);
@@ -104,7 +104,7 @@ If you are using the beta, use this instead:
 (function() {
     var checkReady = setInterval(function() {
         if (typeof Game.ready !== 'undefined' && Game.ready) {
-            Game.LoadMod('http://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
+            Game.LoadMod('https://aktanusa.github.io/CookieMonster/CookieMonsterBeta.js');
             clearInterval(checkReady);
         }
     }, 1000);
@@ -129,7 +129,7 @@ All suggestions are welcome, even the smallest ones.
 
 # Contributors
 
-* **[Raving_Kumquat](http://cookieclicker.wikia.com/wiki/User:Raving_Kumquat)**: Original author
+* **[Raving_Kumquat](https://cookieclicker.wikia.com/wiki/User:Raving_Kumquat)**: Original author
 * **[Maxime Fabre](https://github.com/Anahkiasen)**: Previous maintainer
 * **[Alderi Tokori](http://forum.dashnet.org/profile/Alderi)**: ROI calculations (unused now)
 * **[Alhifar](https://github.com/Alhifar)**: Missed Golden Cookie Stat


### PR DESCRIPTION
HTTPS is good to push for wherever possible, even if the Cookie Clicker site itself does not support it now.