### PR TITLE
Add https inclusion to userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you'd rather use the addon as a script via per example *Greasemonkey* or *Tam
 // @name Cookie Monster
 // @namespace Cookie
 // @include http://orteil.dashnet.org/cookieclicker/
+// @include https://orteil.dashnet.org/cookieclicker/
 // @version 1
 // @grant none
 // ==/UserScript==
@@ -99,6 +100,7 @@ If you are using the beta, use this instead:
 // @name Cookie Monster Beta
 // @namespace Cookie
 // @include http://orteil.dashnet.org/cookieclicker/beta/
+// @include https://orteil.dashnet.org/cookieclicker/
 // @version 1
 // @grant none
 // ==/UserScript==


### PR DESCRIPTION
The game wouldn't load with the default http include when using https on the cookie clicker page.