### PR TITLE
Implement Krumblor aura comparisons [RFC]

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2593,16 +2593,35 @@ CM.Disp.RefreshScale = function() {
 
 CM.Disp.CreateAuraInfo = function(aura) {
 	var auraInfo = document.createElement("div");
+	auraInfo.id = "CMAuraInfo";
 	// TODO: Run aura sim
+	
+	var auraBorder = document.createElement("div");
+	auraBorder.style.border = "1px solid";
+	auraBorder.style.padding = "4px";
+	auraBorder.style.margin = "6px";
+	auraBorder.id = "CMAuraBorder";
+	auraBorder.className = CM.Disp.colorTextPre + CM.Disp.colorGray; // TODO: Border color?
+	auraInfo.appendChild(auraBorder);
+	
+	var changeTitle = document.createElement("div");
+	changeTitle.style.fontWeight = "bold";
+	changeTitle.className = "CMTextBlue";
+	changeTitle.innerText = "Change in Income";
+	auraBorder.appendChild(changeTitle);
+	
+	var changeValue = document.createElement("div");
+	changeValue.id = "CMAuraIncome";
+	changeValue.innerText = "0";
+	auraBorder.appendChild(changeValue);
+	
 	return auraInfo;
 }
 
 CM.Disp.DescribeDragonAura = function(aura) {
 	var auraInfo = l("dragonAuraInfo");
-	var line = document.createElement("div");
-	line.setAttribute("class", "line");
-	auraInfo.firstElementChild.appendChild(line);
-	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura))
+	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura));
+	// TODO: Add color tips to crates, if desired
 }
 
 CM.Disp.colorTextPre = 'CMText';

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2594,7 +2594,8 @@ CM.Disp.RefreshScale = function() {
 CM.Disp.CreateAuraInfo = function(aura) {
 	var auraInfo = document.createElement("div");
 	auraInfo.id = "CMAuraInfo";
-	// TODO: Run aura sim
+	
+	CM.Sim.ChangeAura(aura);
 	
 	var auraBorder = document.createElement("div");
 	auraBorder.style.border = "1px solid";
@@ -2612,7 +2613,7 @@ CM.Disp.CreateAuraInfo = function(aura) {
 	
 	var changeValue = document.createElement("div");
 	changeValue.id = "CMAuraIncome";
-	changeValue.innerText = "0";
+	changeValue.innerText = Beautify(CM.Sim.cookiesPs - Game.cookiesPs);
 	auraBorder.appendChild(changeValue);
 	
 	return auraInfo;
@@ -3455,6 +3456,40 @@ CM.Sim.BuyUpgrades = function() {
 			CM.Cache.Upgrades[i].bonus = CM.Sim.cookiesPs - Game.cookiesPs;
 		}
 	}
+}
+
+CM.Sim.ChangeAura = function(aura) {
+	CM.Sim.CopyData();
+	CM.Sim.dragonAura = aura;
+	
+	var highest = 0;
+	for (var i in CM.Sim.Objects) {
+		if (CM.Sim.Objects[i].amount > 0) {
+			highest = i;
+		}
+	}
+	if (highest != 0) {
+		CM.Sim.Objects[highest].amount -= 1;
+	}
+	
+	CM.Sim.CalculateGains();
+}
+
+CM.Sim.ChangeAura2 = function(aura) {
+	CM.Sim.CopyData();
+	CM.Sim.dragonAura2 = aura;
+
+	var highest = -1;
+	for (var i in CM.Sim.Objects) {
+		if (CM.Sim.Objects[i].amount > 0) {
+			highest = i;
+		}
+	}
+	if (highest != 0) {
+		CM.Sim.Objects[highest].amount -= 1;
+	}
+	
+	CM.Sim.CalculateGains();
 }
 
 CM.Sim.NoGoldSwitchCookiesPS = function() {

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -391,6 +391,11 @@ CM.Cache.ClicksDiff;
 CM.Cache.AvgCPS = -1;
 CM.Cache.AvgCPSChoEgg = -1;
 CM.Cache.AvgClicks = -1;
+CM.Cache.HighestBuilding = -1;
+CM.Cache.MinAura = 0;
+CM.Cache.MaxAura = 0;
+CM.Cache.MinAura2 = 0;
+CM.Cache.MaxAura2 = 0;
 
 /**********
  * Config *
@@ -2591,18 +2596,34 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
+CM.Disp.GetAuraColor = function(aura) {
+    var borderColor = CM.Disp.colorGray;
+    
+    if (aura == Game.dragonAura) {
+        borderColor = CM.Disp.colorGray;
+    } else if (CM.Cache.Auras[aura] == CM.Cache.MaxAura) {
+        borderColor = CM.Disp.colorBlue;
+    } else if (CM.Cache.Auras[aura] == CM.Cache.MinAura) {
+        borderColor = CM.Disp.colorPurple;
+    } else if (CM.Cache.Auras[aura] > 0) {
+        borderColor = CM.Disp.colorGreen;
+    } else if (CM.Cache.Auras[aura] < 0) {
+        borderColor = CM.Disp.colorRed;
+    }
+    
+    return borderColor;
+}
+
 CM.Disp.CreateAuraInfo = function(aura) {
-	var auraInfo = document.createElement("div");
-	auraInfo.id = "CMAuraInfo";
-	
-	CM.Sim.ChangeAura(aura);
-	
-	var auraBorder = document.createElement("div");
-	auraBorder.style.border = "1px solid";
-	auraBorder.style.padding = "4px";
-	auraBorder.style.margin = "6px";
-	auraBorder.id = "CMAuraBorder";
-	auraBorder.className = CM.Disp.colorTextPre + CM.Disp.colorGray; // TODO: Border color?
+    var auraInfo = document.createElement("div");
+    auraInfo.id = "CMAuraInfo";
+
+    var auraBorder = document.createElement("div");
+    auraBorder.style.border = "1px solid";
+    auraBorder.style.padding = "4px";
+    auraBorder.style.margin = "6px";
+    auraBorder.id = "CMAuraBorder";
+    auraBorder.className = CM.Disp.colorTextPre + CM.Disp.GetAuraColor(aura);
 	auraInfo.appendChild(auraBorder);
 	
 	var changeTitle = document.createElement("div");
@@ -2613,16 +2634,29 @@ CM.Disp.CreateAuraInfo = function(aura) {
 	
 	var changeValue = document.createElement("div");
 	changeValue.id = "CMAuraIncome";
-	changeValue.innerText = Beautify(CM.Sim.cookiesPs - Game.cookiesPs);
+	changeValue.innerText = Beautify(CM.Cache.Auras[aura]);
 	auraBorder.appendChild(changeValue);
 	
 	return auraInfo;
 }
 
 CM.Disp.DescribeDragonAura = function(aura) {
+    CM.Sim.CalculateAuras();
 	var auraInfo = l("dragonAuraInfo");
 	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura));
-	// TODO: Add color tips to crates, if desired
+	
+	var auraList = auraInfo.nextElementSibling;
+    for (var i in auraList.children) {
+        var crate = auraList.children[i];
+        if (crate && crate.children && crate.children.length == 0) {
+            var colorDiv = document.createElement("div");
+            colorDiv.className = CM.Disp.colorBackPre + CM.Disp.GetAuraColor(i);
+            colorDiv.style.height = "10px";
+            colorDiv.style.width = "10px";
+
+            auraList.children[i].appendChild(colorDiv);
+        }
+    }
 }
 
 CM.Disp.colorTextPre = 'CMText';
@@ -3458,38 +3492,86 @@ CM.Sim.BuyUpgrades = function() {
 	}
 }
 
+CM.Sim.CalculateHighest = function() {
+    var highest = -1;
+    for (var i in CM.Sim.Objects) {
+        if (CM.Sim.Objects[i].amount > 0) {
+            highest = i;
+        }
+    }
+    CM.Cache.HighestBuilding = highest;
+}
+
 CM.Sim.ChangeAura = function(aura) {
-	CM.Sim.CopyData();
-	CM.Sim.dragonAura = aura;
-	
-	var highest = 0;
-	for (var i in CM.Sim.Objects) {
-		if (CM.Sim.Objects[i].amount > 0) {
-			highest = i;
-		}
-	}
-	if (highest != 0) {
-		CM.Sim.Objects[highest].amount -= 1;
-	}
-	
+    // Changing to the current aura costs nothing and does nothing
+    if (aura != CM.Sim.dragonAura) {
+        CM.Sim.dragonAura = aura;
+
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount >= 0) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount -= 1;
+        }
+    }
 	CM.Sim.CalculateGains();
 }
 
 CM.Sim.ChangeAura2 = function(aura) {
-	CM.Sim.CopyData();
-	CM.Sim.dragonAura2 = aura;
+    // Changing to the current aura costs nothing and does nothing
+    if (aura != CM.Sim.dragonAura2) {
+        CM.Sim.dragonAura2 = aura;
 
-	var highest = -1;
-	for (var i in CM.Sim.Objects) {
-		if (CM.Sim.Objects[i].amount > 0) {
-			highest = i;
-		}
-	}
-	if (highest != 0) {
-		CM.Sim.Objects[highest].amount -= 1;
-	}
-	
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount >= 0) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount -= 1;
+        }
+    }
 	CM.Sim.CalculateGains();
+}
+
+CM.Sim.CalculateAuras = function() {
+    CM.Cache.Auras = [];
+    CM.Cache.Auras2 = [];
+    
+    var origAura = CM.Sim.dragonAura;
+    var origAura2 = CM.Sim.dragonAura2;
+    CM.Sim.CalculateHighest();
+    for (var i in Game.dragonAuras) {
+        CM.Sim.CopyData();
+        
+        var startAmount = CM.Sim.Objects[CM.Cache.HighestBuilding];
+        
+        CM.Sim.ChangeAura(i);
+        CM.Cache.Auras[i] = CM.Sim.cookiesPs - Game.cookiesPs;
+        CM.Sim.dragonAura = origAura;
+        
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount != startAmount) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount += 1;
+        }
+        
+        CM.Sim.ChangeAura2(i);
+        CM.Cache.Auras2[i] = CM.Sim.cookiesPs - Game.cookiesPs;
+        CM.Sim.dragonAura2 = origAura2;
+    }
+    
+    CM.Cache.MinAura = null;
+    CM.Cache.MaxAura = null;
+    for (var i in CM.Cache.Auras) {
+        if (CM.Cache.MinAura == null || CM.Cache.Auras[i] < CM.Cache.MinAura) {
+            CM.Cache.MinAura = CM.Cache.Auras[i];
+        }
+        if (CM.Cache.MaxAura == null || CM.Cache.Auras[i] > CM.Cache.MaxAura) {
+            CM.Cache.MaxAura = CM.Cache.Auras[i];
+        }
+    }
+    
+    CM.Cache.MinAura2 = 0;
+    CM.Cache.MaxAura2 = 0;
+    for (var i in CM.Cache.Auras2) {
+        if (CM.Cache.MinAura2 == null || CM.Cache.Auras2[i] < CM.Cache.MinAura2) {
+            CM.Cache.MinAura2 = CM.Cache.Auras2[i];
+        }
+        if (CM.Cache.MaxAura2 == null || CM.Cache.Auras2[i] > CM.Cache.MaxAura2) {
+            CM.Cache.MaxAura2 = CM.Cache.Auras2[i];
+        }
+    }
 }
 
 CM.Sim.NoGoldSwitchCookiesPS = function() {

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -582,7 +582,7 @@ CM.ConfigData.Scale = {label: ['Game\'s Setting Scale', 'Metric', 'Short Scale',
 CM.Data.HalloCookies = ['Skull cookies', 'Ghost cookies', 'Bat cookies', 'Slime cookies', 'Pumpkin cookies', 'Eyeball cookies', 'Spider cookies'];
 CM.Data.ChristCookies = ['Christmas tree biscuits', 'Snowflake biscuits', 'Snowman biscuits', 'Holly biscuits', 'Candy cane biscuits', 'Bell biscuits', 'Present biscuits'];
 CM.Data.ValCookies = ['Pure heart biscuits', 'Ardent heart biscuits', 'Sour heart biscuits', 'Weeping heart biscuits', 'Golden heart biscuits', 'Eternal heart biscuits'];
-
+CM.Data.CalculableAuras = ['No aura', 'Breath of Milk', 'Elder Battalion', 'Dragon God', 'Radiant Appetite'];
 /********
  * Disp *
  ********/
@@ -2599,15 +2599,17 @@ CM.Disp.RefreshScale = function() {
 CM.Disp.GetAuraColor = function(aura) {
     var borderColor = CM.Disp.colorGray;
     
-    if (aura == Game.dragonAura) {
+    var delta = CM.Cache.Auras[aura];
+    
+    if (/*aura == Game.dragonAura || */!CM.Data.CalculableAuras.includes(Game.dragonAuras[aura].name)) {
         borderColor = CM.Disp.colorGray;
-    } else if (CM.Cache.Auras[aura] == CM.Cache.MaxAura) {
+    } else if (delta == CM.Cache.MaxAura) {
         borderColor = CM.Disp.colorBlue;
-    } else if (CM.Cache.Auras[aura] == CM.Cache.MinAura) {
+    } else if (delta == CM.Cache.MinAura) {
         borderColor = CM.Disp.colorPurple;
-    } else if (CM.Cache.Auras[aura] > 0) {
+    } else if (delta > 0) {
         borderColor = CM.Disp.colorGreen;
-    } else if (CM.Cache.Auras[aura] < 0) {
+    } else if (delta < 0) {
         borderColor = CM.Disp.colorRed;
     }
     
@@ -3554,22 +3556,24 @@ CM.Sim.CalculateAuras = function() {
     CM.Cache.MinAura = null;
     CM.Cache.MaxAura = null;
     for (var i in CM.Cache.Auras) {
-        if (CM.Cache.MinAura == null || CM.Cache.Auras[i] < CM.Cache.MinAura) {
-            CM.Cache.MinAura = CM.Cache.Auras[i];
+        var delta = CM.Cache.Auras[i];
+        if (CM.Cache.MinAura == null || delta < CM.Cache.MinAura) {
+            CM.Cache.MinAura = delta;
         }
-        if (CM.Cache.MaxAura == null || CM.Cache.Auras[i] > CM.Cache.MaxAura) {
-            CM.Cache.MaxAura = CM.Cache.Auras[i];
+        if (CM.Cache.MaxAura == null || delta > CM.Cache.MaxAura) {
+            CM.Cache.MaxAura = delta;
         }
     }
     
     CM.Cache.MinAura2 = 0;
     CM.Cache.MaxAura2 = 0;
     for (var i in CM.Cache.Auras2) {
-        if (CM.Cache.MinAura2 == null || CM.Cache.Auras2[i] < CM.Cache.MinAura2) {
-            CM.Cache.MinAura2 = CM.Cache.Auras2[i];
+        var delta = CM.Cache.Auras2[i];
+        if (CM.Cache.MinAura2 == null || delta < CM.Cache.MinAura2) {
+            CM.Cache.MinAura2 = delta;
         }
         if (CM.Cache.MaxAura2 == null || CM.Cache.Auras2[i] > CM.Cache.MaxAura2) {
-            CM.Cache.MaxAura2 = CM.Cache.Auras2[i];
+            CM.Cache.MaxAura2 = delta;
         }
     }
 }

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2591,9 +2591,18 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
-CM.Disp.DescribeDragonAura = function() {
-	l("")
-	// TODO
+CM.Disp.CreateAuraInfo = function(aura) {
+	var auraInfo = document.createElement("div");
+	// TODO: Run aura sim
+	return auraInfo;
+}
+
+CM.Disp.DescribeDragonAura = function(aura) {
+	var auraInfo = l("dragonAuraInfo");
+	var line = document.createElement("div");
+	line.setAttribute("class", "line");
+	auraInfo.firstElementChild.appendChild(line);
+	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura))
 }
 
 CM.Disp.colorTextPre = 'CMText';
@@ -2680,9 +2689,10 @@ CM.ReplaceNative = function() {
 		CM.Disp.FixMouseY(CM.Backup.UpdateSpecial);
 	}
 	
-	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura
-	Game.DescribeDragonAura = function() {
-		CM.Disp.DescribeDragonAura()
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura;
+	Game.DescribeDragonAura = function(aura) {
+		CM.Backup.DescribeDragonAura(aura);
+		CM.Disp.DescribeDragonAura(aura);
 	}
 
 	// Assumes newer browsers

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2591,6 +2591,11 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
+CM.Disp.DescribeDragonAura = function() {
+	l("")
+	// TODO
+}
+
 CM.Disp.colorTextPre = 'CMText';
 CM.Disp.colorBackPre = 'CMBack';
 CM.Disp.colorBorderPre = 'CMBorder';
@@ -2673,6 +2678,11 @@ CM.ReplaceNative = function() {
 	CM.Backup.UpdateSpecial = Game.UpdateSpecial;
 	Game.UpdateSpecial = function() {
 		CM.Disp.FixMouseY(CM.Backup.UpdateSpecial);
+	}
+	
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura
+	Game.DescribeDragonAura = function() {
+		CM.Disp.DescribeDragonAura()
 	}
 
 	// Assumes newer browsers

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -371,4 +371,9 @@ CM.Cache.ClicksDiff;
 CM.Cache.AvgCPS = -1;
 CM.Cache.AvgCPSChoEgg = -1;
 CM.Cache.AvgClicks = -1;
+CM.Cache.HighestBuilding = -1;
+CM.Cache.MinAura = 0;
+CM.Cache.MaxAura = 0;
+CM.Cache.MinAura2 = 0;
+CM.Cache.MaxAura2 = 0;
 

--- a/src/Data.js
+++ b/src/Data.js
@@ -5,4 +5,4 @@
 CM.Data.HalloCookies = ['Skull cookies', 'Ghost cookies', 'Bat cookies', 'Slime cookies', 'Pumpkin cookies', 'Eyeball cookies', 'Spider cookies'];
 CM.Data.ChristCookies = ['Christmas tree biscuits', 'Snowflake biscuits', 'Snowman biscuits', 'Holly biscuits', 'Candy cane biscuits', 'Bell biscuits', 'Present biscuits'];
 CM.Data.ValCookies = ['Pure heart biscuits', 'Ardent heart biscuits', 'Sour heart biscuits', 'Weeping heart biscuits', 'Golden heart biscuits', 'Eternal heart biscuits'];
-
+CM.Data.CalculableAuras = ['No aura', 'Breath of Milk', 'Elder Battalion', 'Dragon God', 'Radiant Appetite'];

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2013,16 +2013,35 @@ CM.Disp.RefreshScale = function() {
 
 CM.Disp.CreateAuraInfo = function(aura) {
 	var auraInfo = document.createElement("div");
+	auraInfo.id = "CMAuraInfo";
 	// TODO: Run aura sim
+	
+	var auraBorder = document.createElement("div");
+	auraBorder.style.border = "1px solid";
+	auraBorder.style.padding = "4px";
+	auraBorder.style.margin = "6px";
+	auraBorder.id = "CMAuraBorder";
+	auraBorder.className = CM.Disp.colorTextPre + CM.Disp.colorGray; // TODO: Border color?
+	auraInfo.appendChild(auraBorder);
+	
+	var changeTitle = document.createElement("div");
+	changeTitle.style.fontWeight = "bold";
+	changeTitle.className = "CMTextBlue";
+	changeTitle.innerText = "Change in Income";
+	auraBorder.appendChild(changeTitle);
+	
+	var changeValue = document.createElement("div");
+	changeValue.id = "CMAuraIncome";
+	changeValue.innerText = "0";
+	auraBorder.appendChild(changeValue);
+	
 	return auraInfo;
 }
 
 CM.Disp.DescribeDragonAura = function(aura) {
 	var auraInfo = l("dragonAuraInfo");
-	var line = document.createElement("div");
-	line.setAttribute("class", "line");
-	auraInfo.firstElementChild.appendChild(line);
-	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura))
+	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura));
+	// TODO: Add color tips to crates, if desired
 }
 
 CM.Disp.colorTextPre = 'CMText';

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2014,7 +2014,8 @@ CM.Disp.RefreshScale = function() {
 CM.Disp.CreateAuraInfo = function(aura) {
 	var auraInfo = document.createElement("div");
 	auraInfo.id = "CMAuraInfo";
-	// TODO: Run aura sim
+	
+	CM.Sim.ChangeAura(aura);
 	
 	var auraBorder = document.createElement("div");
 	auraBorder.style.border = "1px solid";
@@ -2032,7 +2033,7 @@ CM.Disp.CreateAuraInfo = function(aura) {
 	
 	var changeValue = document.createElement("div");
 	changeValue.id = "CMAuraIncome";
-	changeValue.innerText = "0";
+	changeValue.innerText = Beautify(CM.Sim.cookiesPs - Game.cookiesPs);
 	auraBorder.appendChild(changeValue);
 	
 	return auraInfo;

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2011,6 +2011,11 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
+CM.Disp.DescribeDragonAura = function() {
+	l("")
+	// TODO
+}
+
 CM.Disp.colorTextPre = 'CMText';
 CM.Disp.colorBackPre = 'CMBack';
 CM.Disp.colorBorderPre = 'CMBorder';

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2014,15 +2014,17 @@ CM.Disp.RefreshScale = function() {
 CM.Disp.GetAuraColor = function(aura) {
     var borderColor = CM.Disp.colorGray;
     
-    if (aura == Game.dragonAura) {
+    var delta = CM.Cache.Auras[aura];
+    
+    if (!CM.Data.CalculableAuras.includes(Game.dragonAuras[aura].name)) {
         borderColor = CM.Disp.colorGray;
-    } else if (CM.Cache.Auras[aura] == CM.Cache.MaxAura) {
+    } else if (delta == CM.Cache.MaxAura) {
         borderColor = CM.Disp.colorBlue;
-    } else if (CM.Cache.Auras[aura] == CM.Cache.MinAura) {
+    } else if (delta == CM.Cache.MinAura) {
         borderColor = CM.Disp.colorPurple;
-    } else if (CM.Cache.Auras[aura] > 0) {
+    } else if (delta > 0) {
         borderColor = CM.Disp.colorGreen;
-    } else if (CM.Cache.Auras[aura] < 0) {
+    } else if (delta < 0) {
         borderColor = CM.Disp.colorRed;
     }
     

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2011,18 +2011,34 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
+CM.Disp.GetAuraColor = function(aura) {
+    var borderColor = CM.Disp.colorGray;
+    
+    if (aura == Game.dragonAura) {
+        borderColor = CM.Disp.colorGray;
+    } else if (CM.Cache.Auras[aura] == CM.Cache.MaxAura) {
+        borderColor = CM.Disp.colorBlue;
+    } else if (CM.Cache.Auras[aura] == CM.Cache.MinAura) {
+        borderColor = CM.Disp.colorPurple;
+    } else if (CM.Cache.Auras[aura] > 0) {
+        borderColor = CM.Disp.colorGreen;
+    } else if (CM.Cache.Auras[aura] < 0) {
+        borderColor = CM.Disp.colorRed;
+    }
+    
+    return borderColor;
+}
+
 CM.Disp.CreateAuraInfo = function(aura) {
-	var auraInfo = document.createElement("div");
-	auraInfo.id = "CMAuraInfo";
-	
-	CM.Sim.ChangeAura(aura);
-	
-	var auraBorder = document.createElement("div");
-	auraBorder.style.border = "1px solid";
-	auraBorder.style.padding = "4px";
-	auraBorder.style.margin = "6px";
-	auraBorder.id = "CMAuraBorder";
-	auraBorder.className = CM.Disp.colorTextPre + CM.Disp.colorGray; // TODO: Border color?
+    var auraInfo = document.createElement("div");
+    auraInfo.id = "CMAuraInfo";
+
+    var auraBorder = document.createElement("div");
+    auraBorder.style.border = "1px solid";
+    auraBorder.style.padding = "4px";
+    auraBorder.style.margin = "6px";
+    auraBorder.id = "CMAuraBorder";
+    auraBorder.className = CM.Disp.colorTextPre + CM.Disp.GetAuraColor(aura);
 	auraInfo.appendChild(auraBorder);
 	
 	var changeTitle = document.createElement("div");
@@ -2033,16 +2049,29 @@ CM.Disp.CreateAuraInfo = function(aura) {
 	
 	var changeValue = document.createElement("div");
 	changeValue.id = "CMAuraIncome";
-	changeValue.innerText = Beautify(CM.Sim.cookiesPs - Game.cookiesPs);
+	changeValue.innerText = Beautify(CM.Cache.Auras[aura]);
 	auraBorder.appendChild(changeValue);
 	
 	return auraInfo;
 }
 
 CM.Disp.DescribeDragonAura = function(aura) {
+    CM.Sim.CalculateAuras();
 	var auraInfo = l("dragonAuraInfo");
 	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura));
-	// TODO: Add color tips to crates, if desired
+	
+	var auraList = auraInfo.nextElementSibling;
+    for (var i in auraList.children) {
+        var crate = auraList.children[i];
+        if (crate && crate.children && crate.children.length == 0) {
+            var colorDiv = document.createElement("div");
+            colorDiv.className = CM.Disp.colorBackPre + CM.Disp.GetAuraColor(i);
+            colorDiv.style.height = "10px";
+            colorDiv.style.width = "10px";
+
+            auraList.children[i].appendChild(colorDiv);
+        }
+    }
 }
 
 CM.Disp.colorTextPre = 'CMText';

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2011,9 +2011,18 @@ CM.Disp.RefreshScale = function() {
 	CM.Disp.UpdateUpgrades();
 }
 
-CM.Disp.DescribeDragonAura = function() {
-	l("")
-	// TODO
+CM.Disp.CreateAuraInfo = function(aura) {
+	var auraInfo = document.createElement("div");
+	// TODO: Run aura sim
+	return auraInfo;
+}
+
+CM.Disp.DescribeDragonAura = function(aura) {
+	var auraInfo = l("dragonAuraInfo");
+	var line = document.createElement("div");
+	line.setAttribute("class", "line");
+	auraInfo.firstElementChild.appendChild(line);
+	auraInfo.firstElementChild.appendChild(CM.Disp.CreateAuraInfo(aura))
 }
 
 CM.Disp.colorTextPre = 'CMText';

--- a/src/Main.js
+++ b/src/Main.js
@@ -38,6 +38,11 @@ CM.ReplaceNative = function() {
 	Game.UpdateSpecial = function() {
 		CM.Disp.FixMouseY(CM.Backup.UpdateSpecial);
 	}
+	
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura
+	Game.DescribeDragonAura = function() {
+		CM.Disp.DescribeDragonAura()
+	}
 
 	// Assumes newer browsers
 	l('bigCookie').removeEventListener('click', Game.ClickCookie, false);

--- a/src/Main.js
+++ b/src/Main.js
@@ -39,9 +39,10 @@ CM.ReplaceNative = function() {
 		CM.Disp.FixMouseY(CM.Backup.UpdateSpecial);
 	}
 	
-	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura
-	Game.DescribeDragonAura = function() {
-		CM.Disp.DescribeDragonAura()
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura;
+	Game.DescribeDragonAura = function(aura) {
+		CM.Backup.DescribeDragonAura(aura);
+		CM.Disp.DescribeDragonAura(aura);
 	}
 
 	// Assumes newer browsers

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -485,6 +485,40 @@ CM.Sim.BuyUpgrades = function() {
 	}
 }
 
+CM.Sim.ChangeAura = function(aura) {
+	CM.Sim.CopyData();
+	CM.Sim.dragonAura = aura;
+	
+	var highest = 0;
+	for (var i in CM.Sim.Objects) {
+		if (CM.Sim.Objects[i].amount > 0) {
+			highest = i;
+		}
+	}
+	if (highest != 0) {
+		CM.Sim.Objects[highest].amount -= 1;
+	}
+	
+	CM.Sim.CalculateGains();
+}
+
+CM.Sim.ChangeAura2 = function(aura) {
+	CM.Sim.CopyData();
+	CM.Sim.dragonAura2 = aura;
+
+	var highest = -1;
+	for (var i in CM.Sim.Objects) {
+		if (CM.Sim.Objects[i].amount > 0) {
+			highest = i;
+		}
+	}
+	if (highest != 0) {
+		CM.Sim.Objects[highest].amount -= 1;
+	}
+	
+	CM.Sim.CalculateGains();
+}
+
 CM.Sim.NoGoldSwitchCookiesPS = function() {
 	if (Game.Has('Golden switch [off]')) {
 		CM.Sim.CopyData();

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -547,22 +547,24 @@ CM.Sim.CalculateAuras = function() {
     CM.Cache.MinAura = null;
     CM.Cache.MaxAura = null;
     for (var i in CM.Cache.Auras) {
-        if (CM.Cache.MinAura == null || CM.Cache.Auras[i] < CM.Cache.MinAura) {
-            CM.Cache.MinAura = CM.Cache.Auras[i];
+        var delta = CM.Cache.Auras[i];
+        if (CM.Cache.MinAura == null || delta < CM.Cache.MinAura) {
+            CM.Cache.MinAura = delta;
         }
-        if (CM.Cache.MaxAura == null || CM.Cache.Auras[i] > CM.Cache.MaxAura) {
-            CM.Cache.MaxAura = CM.Cache.Auras[i];
+        if (CM.Cache.MaxAura == null || delta > CM.Cache.MaxAura) {
+            CM.Cache.MaxAura = delta;
         }
     }
     
     CM.Cache.MinAura2 = 0;
     CM.Cache.MaxAura2 = 0;
     for (var i in CM.Cache.Auras2) {
-        if (CM.Cache.MinAura2 == null || CM.Cache.Auras2[i] < CM.Cache.MinAura2) {
-            CM.Cache.MinAura2 = CM.Cache.Auras2[i];
+        var delta = CM.Cache.Auras2[i];
+        if (CM.Cache.MinAura2 == null || delta < CM.Cache.MinAura2) {
+            CM.Cache.MinAura2 = delta;
         }
         if (CM.Cache.MaxAura2 == null || CM.Cache.Auras2[i] > CM.Cache.MaxAura2) {
-            CM.Cache.MaxAura2 = CM.Cache.Auras2[i];
+            CM.Cache.MaxAura2 = delta;
         }
     }
 }

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -485,38 +485,86 @@ CM.Sim.BuyUpgrades = function() {
 	}
 }
 
+CM.Sim.CalculateHighest = function() {
+    var highest = -1;
+    for (var i in CM.Sim.Objects) {
+        if (CM.Sim.Objects[i].amount > 0) {
+            highest = i;
+        }
+    }
+    CM.Cache.HighestBuilding = highest;
+}
+
 CM.Sim.ChangeAura = function(aura) {
-	CM.Sim.CopyData();
-	CM.Sim.dragonAura = aura;
-	
-	var highest = 0;
-	for (var i in CM.Sim.Objects) {
-		if (CM.Sim.Objects[i].amount > 0) {
-			highest = i;
-		}
-	}
-	if (highest != 0) {
-		CM.Sim.Objects[highest].amount -= 1;
-	}
-	
+    // Changing to the current aura costs nothing and does nothing
+    if (aura != CM.Sim.dragonAura) {
+        CM.Sim.dragonAura = aura;
+
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount >= 0) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount -= 1;
+        }
+    }
 	CM.Sim.CalculateGains();
 }
 
 CM.Sim.ChangeAura2 = function(aura) {
-	CM.Sim.CopyData();
-	CM.Sim.dragonAura2 = aura;
+    // Changing to the current aura costs nothing and does nothing
+    if (aura != CM.Sim.dragonAura2) {
+        CM.Sim.dragonAura2 = aura;
 
-	var highest = -1;
-	for (var i in CM.Sim.Objects) {
-		if (CM.Sim.Objects[i].amount > 0) {
-			highest = i;
-		}
-	}
-	if (highest != 0) {
-		CM.Sim.Objects[highest].amount -= 1;
-	}
-	
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount >= 0) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount -= 1;
+        }
+    }
 	CM.Sim.CalculateGains();
+}
+
+CM.Sim.CalculateAuras = function() {
+    CM.Cache.Auras = [];
+    CM.Cache.Auras2 = [];
+    
+    var origAura = CM.Sim.dragonAura;
+    var origAura2 = CM.Sim.dragonAura2;
+    CM.Sim.CalculateHighest();
+    for (var i in Game.dragonAuras) {
+        CM.Sim.CopyData();
+        
+        var startAmount = CM.Sim.Objects[CM.Cache.HighestBuilding];
+        
+        CM.Sim.ChangeAura(i);
+        CM.Cache.Auras[i] = CM.Sim.cookiesPs - Game.cookiesPs;
+        CM.Sim.dragonAura = origAura;
+        
+        if (CM.Sim.Objects[CM.Cache.HighestBuilding].amount != startAmount) {
+            CM.Sim.Objects[CM.Cache.HighestBuilding].amount += 1;
+        }
+        
+        CM.Sim.ChangeAura2(i);
+        CM.Cache.Auras2[i] = CM.Sim.cookiesPs - Game.cookiesPs;
+        CM.Sim.dragonAura2 = origAura2;
+    }
+    
+    CM.Cache.MinAura = null;
+    CM.Cache.MaxAura = null;
+    for (var i in CM.Cache.Auras) {
+        if (CM.Cache.MinAura == null || CM.Cache.Auras[i] < CM.Cache.MinAura) {
+            CM.Cache.MinAura = CM.Cache.Auras[i];
+        }
+        if (CM.Cache.MaxAura == null || CM.Cache.Auras[i] > CM.Cache.MaxAura) {
+            CM.Cache.MaxAura = CM.Cache.Auras[i];
+        }
+    }
+    
+    CM.Cache.MinAura2 = 0;
+    CM.Cache.MaxAura2 = 0;
+    for (var i in CM.Cache.Auras2) {
+        if (CM.Cache.MinAura2 == null || CM.Cache.Auras2[i] < CM.Cache.MinAura2) {
+            CM.Cache.MinAura2 = CM.Cache.Auras2[i];
+        }
+        if (CM.Cache.MaxAura2 == null || CM.Cache.Auras2[i] > CM.Cache.MaxAura2) {
+            CM.Cache.MaxAura2 = CM.Cache.Auras2[i];
+        }
+    }
 }
 
 CM.Sim.NoGoldSwitchCookiesPS = function() {


### PR DESCRIPTION
Draft PR to solicit thoughts and answer questions

This is an attempt to implement CPS prediction for Krumblor auras, the ones that have calculable bonuses at least.

Open questions:
- ~~How to handle simulation of Auras? I've never touched this project before, so I'm not quite sure how `CM.Sim` works~~
- ~~Should I continue on the path of 'DescribeDragonAura' override? Or should I add it in somewhere else so that it is re-calculated every tick, not only every mouseon-mouseoff~~