### PR TITLE
Update to 2.029 and Added a Caution for the "Conjure Baked Goods" Spell

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -159,6 +159,8 @@ CM.Cache.RemakeLucky = function() {
 	CM.Cache.LuckyReward = (CM.Cache.Lucky * 0.15) + 13;
 	CM.Cache.LuckyFrenzy = CM.Cache.Lucky * 7;
 	CM.Cache.LuckyRewardFrenzy = (CM.Cache.LuckyFrenzy * 0.15) + 13;
+	CM.Cache.Conjure = CM.Cache.Lucky * 2;
+	CM.Cache.ConjureReward = CM.Cache.Conjure * 0.15;
 }
 
 CM.Cache.MaxChainMoni = function(digit, maxPayout) {
@@ -377,6 +379,8 @@ CM.Cache.Lucky = 0;
 CM.Cache.LuckyReward = 0;
 CM.Cache.LuckyFrenzy = 0;
 CM.Cache.LuckyRewardFrenzy = 0;
+CM.Cache.Conjure = 0;
+CM.Cache.ConjureReward = 0;
 CM.Cache.SeaSpec = 0;
 CM.Cache.Chain = 0;
 CM.Cache.ChainWrath = 0;
@@ -1911,6 +1915,9 @@ CM.Disp.AddMenuStats = function(title) {
 		var luckyColorFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var luckyTimeFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.FormatTime((CM.Cache.LuckyFrenzy - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var luckyCurBase = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 15) + 13;
+		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
+		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
+		var conjureRewardMax = CM.Cache.ConjureReward;
 		var luckyRewardMax = CM.Cache.LuckyReward;
 		var luckyRewardMaxWrath = CM.Cache.LuckyReward;
 		var luckyRewardFrenzyMax = CM.Cache.LuckyRewardFrenzy;
@@ -1961,6 +1968,20 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardMax) + (luckySplit ? (' / ' + Beautify(luckyRewardMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX) (Frenzy)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardFrenzyMax) + (luckySplit ? (' / ' + Beautify(luckyRewardFrenzyMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur) + (luckySplit ? (' / ' + Beautify(luckyCurWrath)) : ''))));
+		var conjureReqFrag = document.createDocumentFragment();
+		var conjureReqSpan = document.createElement('span');
+		conjureReqSpan.style.fontWeight = 'bold';
+		conjureReqSpan.className = CM.Disp.colorTextPre + luckyColor;
+		conjureReqSpan.textContent = Beautify(CM.Cache.Conjure);
+		conjureReqFrag.appendChild(conjureReqSpan);
+		if (conjureTime != '') {
+			var conjureReqSmall = document.createElement('small');
+			conjureReqSmall.textContent = ' (' + conjureTime + ')';
+			conjureReqFrag.appendChild(conjureReqSmall);
+		}
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Cookies Required', 'GoldCookTooltipPlaceholder'), conjureReqFrag));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur))));
 	}
 
 	stats.appendChild(header('Chain Cookies', 'Chain'));
@@ -3036,7 +3057,7 @@ CM.ConfigDefault = {
 };
 CM.ConfigPrefix = 'CMConfig';
 
-CM.VersionMajor = '2.022';
+CM.VersionMajor = '2.029';
 CM.VersionMinor = '1';
 
 /*******

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2250,6 +2250,8 @@ CM.Disp.CreateTooltipWarnCaut = function() {
 	}
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipWarn', CM.Disp.colorRed, 'Warning: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!"', 'CMDispTooltipWarnText'));
 	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut2', CM.Disp.colorPurple, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Conjure Baked Goods"', 'CMDispTooltipCaut2Text'));
+	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut', CM.Disp.colorYellow, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!" (Frenzy)', 'CMDispTooltipCautText'));
 
 	l('tooltipAnchor').appendChild(CM.Disp.TooltipWarnCaut);
@@ -2474,8 +2476,9 @@ CM.Disp.UpdateTooltip = function() {
 						warn += ((bonusNoFren * 60 * 15) / 0.15);
 					}
 					var caut = warn * 7;
+					var caut2 = warn * 2;
 					var amount = (Game.cookies + CM.Disp.GetWrinkConfigBank()) - price;
-					if ((amount < warn || amount < caut) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
+					if ((amount < warn || amount < caut2 || amount < caut) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
 						if (CM.Config.ToolWarnCautPos == 0) {
 							CM.Disp.TooltipWarnCaut.style.right = '0px';
 						}
@@ -2487,21 +2490,33 @@ CM.Disp.UpdateTooltip = function() {
 						if (amount < warn) {
 							l('CMDispTooltipWarn').style.display = '';
 							l('CMDispTooltipWarnText').textContent = Beautify(warn - amount) + ' (' + CM.Disp.FormatTime((warn - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipCaut2').style.display = '';
+							l('CMDispTooltipCaut2Text').textContent = Beautify(caut2 - amount) + ' (' + CM.Disp.FormatTime((caut2 - amount) / CM.Disp.GetCPS()) + ')';
 							l('CMDispTooltipCaut').style.display = '';
 							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
+						}
+						else if (amount < caut2) {
+							l('CMDispTooltipCaut2').style.display = '';
+							l('CMDispTooltipCaut2Text').textContent = Beautify(caut2 - amount) + ' (' + CM.Disp.FormatTime((caut2 - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipCaut').style.display = '';
+							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipWarn').style.display = 'none';
 						}
 						else if (amount < caut) {
 							l('CMDispTooltipCaut').style.display = '';
 							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
 							l('CMDispTooltipWarn').style.display = 'none';
+							l('CMDispTooltipCaut2').style.display = 'none';
 						}
 						else {
 							l('CMDispTooltipWarn').style.display = 'none';
+							l('CMDispTooltipCaut2').style.display = 'none';
 							l('CMDispTooltipCaut').style.display = 'none';
 						}
 					}
 					else {
 						l('CMDispTooltipWarn').style.display = 'none';
+						l('CMDispTooltipCaut2').style.display = 'none';
 						l('CMDispTooltipCaut').style.display = 'none';
 					}
 				}
@@ -2512,6 +2527,7 @@ CM.Disp.UpdateTooltip = function() {
 			else { // Grimoire
 				CM.Disp.TooltipWarnCaut.style.display = 'none';
 				l('CMDispTooltipWarn').style.display = 'none';
+				l('CMDispTooltipCaut2').style.display = 'none';
 				l('CMDispTooltipCaut').style.display = 'none';
 
 				var minigame = Game.Objects['Wizard tower'].minigame;
@@ -2567,6 +2583,7 @@ CM.Disp.UpdateTooltip = function() {
 CM.Disp.DrawTooltipWarnCaut = function() {
 	if (CM.Config.ToolWarnCaut == 1) {
 		l('CMDispTooltipWarn').style.opacity = '0';
+		l('CMDispTooltipCaut2').style.opacity = '0';
 		l('CMDispTooltipCaut').style.opacity = '0';
 	}
 }
@@ -2574,6 +2591,7 @@ CM.Disp.DrawTooltipWarnCaut = function() {
 CM.Disp.UpdateTooltipWarnCaut = function() {
 	if (CM.Config.ToolWarnCaut == 1 && l('tooltipAnchor').style.display != 'none' && l('CMTooltipArea') != null) {
 		l('CMDispTooltipWarn').style.opacity = '1';
+		l('CMDispTooltipCaut2').style.opacity = '1';
 		l('CMDispTooltipCaut').style.opacity = '1';
 	}
 }
@@ -3242,6 +3260,7 @@ CM.Sim.CalculateGains = function() {
 
 	if (CM.Sim.Has('Fortune #100')) mult *= 1.01;
 	if (CM.Sim.Has('Fortune #101')) mult *= 1.07;
+	if (CM.Sim.Has('Dragon scale')) mult *= 1.03;
 
 	var buildMult = 1;
 	if (Game.hasGod) {
@@ -3425,6 +3444,7 @@ CM.Sim.CheckOtherAchiev = function() {
 	if (minAmount >= 400) CM.Sim.Win('Quadricentennial');
 	if (minAmount >= 450) CM.Sim.Win('Quadricentennial and a half');
 	if (minAmount >= 500) CM.Sim.Win('Quincentennial');
+	if (minAmount >= 550) CM.Sim.Win('Quincentennial and a half');
 
 	if (buildingsOwned >= 100) CM.Sim.Win('Builder');
 	if (buildingsOwned >= 500) CM.Sim.Win('Architect');
@@ -3480,6 +3500,7 @@ CM.Sim.BuyBuildings = function(amount, target) {
 			if (me.amount >= 400) CM.Sim.Win('Dr. T');
 			if (me.amount >= 500) CM.Sim.Win('Thumbs, phalanges, metacarpals');
 			if (me.amount >= 600) CM.Sim.Win('With her finger and her thumb');
+			if (me.amount >= 700) CM.Sim.Win('Gotta hand it to you');
 		}
 		else {
 			for (var j in Game.Objects[me.name].tieredAchievs) {

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -1969,6 +1969,7 @@ CM.Disp.AddMenuStats = function(title) {
 
 	stats.appendChild(header('Conjure Baked Goods', 'Conjure'));
 	if (CM.Config.StatsPref.Conjure) {
+		var conjureColor = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
 		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var conjureRewardMax = CM.Cache.ConjureReward;
@@ -1976,7 +1977,7 @@ CM.Disp.AddMenuStats = function(title) {
 		var conjureReqFrag = document.createDocumentFragment();
 		var conjureReqSpan = document.createElement('span');
 		conjureReqSpan.style.fontWeight = 'bold';
-		conjureReqSpan.className = CM.Disp.colorTextPre + luckyColor;
+		conjureReqSpan.className = CM.Disp.colorTextPre + conjureColor;
 		conjureReqSpan.textContent = Beautify(CM.Cache.Conjure);
 		conjureReqFrag.appendChild(conjureReqSpan);
 		if (conjureTime != '') {
@@ -2275,9 +2276,9 @@ CM.Disp.CreateTooltipWarnCaut = function() {
 		return box;
 	}
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipWarn', CM.Disp.colorRed, 'Warning: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!"', 'CMDispTooltipWarnText'));
-	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.lastChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut2', CM.Disp.colorPurple, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Conjure Baked Goods"', 'CMDispTooltipCaut2Text'));
-	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.lastChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut', CM.Disp.colorYellow, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!" (Frenzy)', 'CMDispTooltipCautText'));
 
 	l('tooltipAnchor').appendChild(CM.Disp.TooltipWarnCaut);

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -1915,9 +1915,6 @@ CM.Disp.AddMenuStats = function(title) {
 		var luckyColorFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var luckyTimeFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.FormatTime((CM.Cache.LuckyFrenzy - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var luckyCurBase = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 15) + 13;
-		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
-		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
-		var conjureRewardMax = CM.Cache.ConjureReward;
 		var luckyRewardMax = CM.Cache.LuckyReward;
 		var luckyRewardMaxWrath = CM.Cache.LuckyReward;
 		var luckyRewardFrenzyMax = CM.Cache.LuckyRewardFrenzy;
@@ -1968,6 +1965,14 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardMax) + (luckySplit ? (' / ' + Beautify(luckyRewardMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX) (Frenzy)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardFrenzyMax) + (luckySplit ? (' / ' + Beautify(luckyRewardFrenzyMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur) + (luckySplit ? (' / ' + Beautify(luckyCurWrath)) : ''))));
+	}
+
+	stats.appendChild(header('Conjure Baked Goods', 'Conjure'));
+	if (CM.Config.StatsPref.Conjure) {
+		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
+		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
+		var conjureRewardMax = CM.Cache.ConjureReward;
+
 		var conjureReqFrag = document.createDocumentFragment();
 		var conjureReqSpan = document.createElement('span');
 		conjureReqSpan.style.fontWeight = 'bold';
@@ -1980,8 +1985,8 @@ CM.Disp.AddMenuStats = function(title) {
 			conjureReqFrag.appendChild(conjureReqSmall);
 		}
 		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Cookies Required', 'GoldCookTooltipPlaceholder'), conjureReqFrag));
-		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
-		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)', 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)', 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureCur))));
 	}
 
 	stats.appendChild(header('Chain Cookies', 'Chain'));
@@ -3052,7 +3057,7 @@ CM.ConfigDefault = {
 	SayTime: 1, 
 	GrimoireBar: 1, 
 	Scale: 2, 
-	StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1}, 
+	StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1, Conjure: 1}, 
 	Colors : {Blue: '#4bb8f0', Green: '#00ff00', Yellow: '#ffff00', Orange: '#ff7f00', Red: '#ff0000', Purple: '#ff00ff', Gray: '#b3b3b3', Pink: '#ff1493', Brown: '#8b4513'}
 };
 CM.ConfigPrefix = 'CMConfig';

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -593,6 +593,30 @@ CM.ConfigData.Scale = {label: ['Game\'s Setting Scale', 'Metric', 'Short Scale',
  * Data *
  ********/
 
+CM.Data.Fortunes = [
+	'Fortune #001', 
+	'Fortune #002', 
+	'Fortune #003', 
+	'Fortune #004', 
+	'Fortune #005', 
+	'Fortune #006', 
+	'Fortune #007', 
+	'Fortune #008', 
+	'Fortune #009', 
+	'Fortune #010', 
+	'Fortune #011', 
+	'Fortune #012', 
+	'Fortune #013', 
+	'Fortune #014', 
+	'Fortune #015', 
+	'Fortune #016', 
+	'Fortune #017', 
+	'Fortune #100', 
+	'Fortune #101', 
+	'Fortune #102', 
+	'Fortune #103', 
+	'Fortune #104'
+];
 CM.Data.HalloCookies = ['Skull cookies', 'Ghost cookies', 'Bat cookies', 'Slime cookies', 'Pumpkin cookies', 'Eyeball cookies', 'Spider cookies'];
 CM.Data.ChristCookies = ['Christmas tree biscuits', 'Snowflake biscuits', 'Snowman biscuits', 'Holly biscuits', 'Candy cane biscuits', 'Bell biscuits', 'Present biscuits'];
 CM.Data.ValCookies = ['Pure heart biscuits', 'Ardent heart biscuits', 'Sour heart biscuits', 'Weeping heart biscuits', 'Golden heart biscuits', 'Eternal heart biscuits'];
@@ -1840,6 +1864,45 @@ CM.Disp.AddMenuStats = function(title) {
 		frag.appendChild(span);
 		return frag;
 	}
+	
+	var createMissDisp = function(theMissDisp) {
+		var frag = document.createDocumentFragment();
+		frag.appendChild(document.createTextNode(theMissDisp.length + ' '));
+		var span = document.createElement('span');
+		span.onmouseout = function() { Game.tooltip.hide(); };
+		var placeholder = document.createElement('div');
+		var missing = document.createElement('div');
+		missing.style.minWidth = '140px';
+		missing.style.marginBottom = '4px';
+		var title = document.createElement('div');
+		title.className = 'name';
+		title.style.marginBottom = '4px';
+		title.style.textAlign = 'center';
+		title.textContent = 'Missing';
+		missing.appendChild(title);
+		for (var i in theMissDisp) {
+			var div = document.createElement('div');
+			div.style.textAlign = 'center';
+			div.appendChild(document.createTextNode(theMissDisp[i]));
+			missing.appendChild(div);
+		}
+		placeholder.appendChild(missing);
+		span.onmouseover = function() {Game.tooltip.draw(this, escape(placeholder.innerHTML));};
+		span.style.cursor = 'default';
+		span.style.display = 'inline-block';
+		span.style.height = '10px';
+		span.style.width = '10px';
+		span.style.borderRadius = '5px';
+		span.style.textAlign = 'center';
+		span.style.backgroundColor = '#C0C0C0';
+		span.style.color = 'black';
+		span.style.fontSize = '9px';
+		span.style.verticalAlign = 'bottom';
+		span.textContent = '?';
+		frag.appendChild(span);
+		return frag;
+	}
+
 
 	stats.appendChild(header('Lucky Cookies', 'Lucky'));
 	if (CM.Config.StatsPref.Lucky) {
@@ -2067,48 +2130,11 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(header('Season Specials', 'Sea'));
 		if (CM.Config.StatsPref.Sea) {
 			if (specDisp) {
-				var createSpecDisp = function(theSpecDisp) {
-					var frag = document.createDocumentFragment();
-					frag.appendChild(document.createTextNode(theSpecDisp.length + ' '));
-					var span = document.createElement('span');
-					span.onmouseout = function() { Game.tooltip.hide(); };
-					var placeholder = document.createElement('div');
-					var missing = document.createElement('div');
-					missing.style.minWidth = '140px';
-					missing.style.marginBottom = '4px';
-					var title = document.createElement('div');
-					title.className = 'name';
-					title.style.marginBottom = '4px';
-					title.style.textAlign = 'center';
-					title.textContent = 'Missing';
-					missing.appendChild(title);
-					for (var i in theSpecDisp) {
-						var div = document.createElement('div');
-						div.style.textAlign = 'center';
-						div.appendChild(document.createTextNode(theSpecDisp[i]));
-						missing.appendChild(div);
-					}
-					placeholder.appendChild(missing);
-					span.onmouseover = function() {Game.tooltip.draw(this, escape(placeholder.innerHTML));};
-					span.style.cursor = 'default';
-					span.style.display = 'inline-block';
-					span.style.height = '10px';
-					span.style.width = '10px';
-					span.style.borderRadius = '5px';
-					span.style.textAlign = 'center';
-					span.style.backgroundColor = '#C0C0C0';
-					span.style.color = 'black';
-					span.style.fontSize = '9px';
-					span.style.verticalAlign = 'bottom';
-					span.textContent = '?';
-					frag.appendChild(span);
-					return frag;
-				}
-				if (halloCook.length != 0) stats.appendChild(listing('Halloween Cookies Left to Buy', createSpecDisp(halloCook)));
-				if (christCook.length != 0) stats.appendChild(listing('Christmas Cookies Left to Buy',  createSpecDisp(christCook)));
-				if (valCook.length != 0) stats.appendChild(listing('Valentine Cookies Left to Buy',  createSpecDisp(valCook)));
-				if (normEggs.length != 0) stats.appendChild(listing('Normal Easter Eggs Left to Unlock',  createSpecDisp(normEggs)));
-				if (rareEggs.length != 0) stats.appendChild(listing('Rare Easter Eggs Left to Unlock',  createSpecDisp(rareEggs)));
+				if (halloCook.length != 0) stats.appendChild(listing('Halloween Cookies Left to Buy', createMissDisp(halloCook)));
+				if (christCook.length != 0) stats.appendChild(listing('Christmas Cookies Left to Buy',  createMissDisp(christCook)));
+				if (valCook.length != 0) stats.appendChild(listing('Valentine Cookies Left to Buy',  createMissDisp(valCook)));
+				if (normEggs.length != 0) stats.appendChild(listing('Normal Easter Eggs Left to Unlock',  createMissDisp(normEggs)));
+				if (rareEggs.length != 0) stats.appendChild(listing('Rare Easter Eggs Left to Unlock',  createMissDisp(rareEggs)));
 			}
 
 			if (Game.season == 'christmas') stats.appendChild(listing('Reindeer Reward',  document.createTextNode(Beautify(CM.Cache.SeaSpec))));
@@ -2128,6 +2154,15 @@ CM.Disp.AddMenuStats = function(title) {
 			document.createTextNode(Beautify(CM.Cache.AvgCPS, 3))
 		));
 		stats.appendChild(listing('Average Cookie Clicks Per Second (Past ' + CM.Disp.clickTimes[CM.Config.AvgClicksHist] + (CM.Config.AvgClicksHist == 0 ? ' second' : ' seconds') + ')', document.createTextNode(Beautify(CM.Cache.AvgClicks, 1))));
+		if (Game.Has('Fortune cookies')) {
+			var fortunes = [];
+			for (var i in CM.Data.Fortunes) {
+				if (!Game.Has(CM.Data.Fortunes[i])) {
+					fortunes.push(CM.Data.Fortunes[i]);
+				}
+			}
+			if (fortunes.length != 0) stats.appendChild(listing('Fortune Upgrades Left to Buy',  createMissDisp(fortunes)));
+		}
 		stats.appendChild(listing('Missed Golden Cookies', document.createTextNode(Beautify(Game.missedGoldenClicks))));
 	}
 

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -139,6 +139,8 @@ CM.Cache.RemakeLucky = function() {
 	CM.Cache.LuckyReward = (CM.Cache.Lucky * 0.15) + 13;
 	CM.Cache.LuckyFrenzy = CM.Cache.Lucky * 7;
 	CM.Cache.LuckyRewardFrenzy = (CM.Cache.LuckyFrenzy * 0.15) + 13;
+	CM.Cache.Conjure = CM.Cache.Lucky * 2;
+	CM.Cache.ConjureReward = CM.Cache.Conjure * 0.15;
 }
 
 CM.Cache.MaxChainMoni = function(digit, maxPayout) {
@@ -357,6 +359,8 @@ CM.Cache.Lucky = 0;
 CM.Cache.LuckyReward = 0;
 CM.Cache.LuckyFrenzy = 0;
 CM.Cache.LuckyRewardFrenzy = 0;
+CM.Cache.Conjure = 0;
+CM.Cache.ConjureReward = 0;
 CM.Cache.SeaSpec = 0;
 CM.Cache.Chain = 0;
 CM.Cache.ChainWrath = 0;

--- a/src/Data.js
+++ b/src/Data.js
@@ -2,6 +2,30 @@
  * Data *
  ********/
 
+CM.Data.Fortunes = [
+	'Fortune #001', 
+	'Fortune #002', 
+	'Fortune #003', 
+	'Fortune #004', 
+	'Fortune #005', 
+	'Fortune #006', 
+	'Fortune #007', 
+	'Fortune #008', 
+	'Fortune #009', 
+	'Fortune #010', 
+	'Fortune #011', 
+	'Fortune #012', 
+	'Fortune #013', 
+	'Fortune #014', 
+	'Fortune #015', 
+	'Fortune #016', 
+	'Fortune #017', 
+	'Fortune #100', 
+	'Fortune #101', 
+	'Fortune #102', 
+	'Fortune #103', 
+	'Fortune #104'
+];
 CM.Data.HalloCookies = ['Skull cookies', 'Ghost cookies', 'Bat cookies', 'Slime cookies', 'Pumpkin cookies', 'Eyeball cookies', 'Spider cookies'];
 CM.Data.ChristCookies = ['Christmas tree biscuits', 'Snowflake biscuits', 'Snowman biscuits', 'Holly biscuits', 'Candy cane biscuits', 'Bell biscuits', 'Present biscuits'];
 CM.Data.ValCookies = ['Pure heart biscuits', 'Ardent heart biscuits', 'Sour heart biscuits', 'Weeping heart biscuits', 'Golden heart biscuits', 'Eternal heart biscuits'];

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1288,6 +1288,9 @@ CM.Disp.AddMenuStats = function(title) {
 		var luckyColorFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var luckyTimeFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.FormatTime((CM.Cache.LuckyFrenzy - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var luckyCurBase = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 15) + 13;
+		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
+		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
+		var conjureRewardMax = CM.Cache.ConjureReward;
 		var luckyRewardMax = CM.Cache.LuckyReward;
 		var luckyRewardMaxWrath = CM.Cache.LuckyReward;
 		var luckyRewardFrenzyMax = CM.Cache.LuckyRewardFrenzy;
@@ -1338,6 +1341,20 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardMax) + (luckySplit ? (' / ' + Beautify(luckyRewardMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX) (Frenzy)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardFrenzyMax) + (luckySplit ? (' / ' + Beautify(luckyRewardFrenzyMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur) + (luckySplit ? (' / ' + Beautify(luckyCurWrath)) : ''))));
+		var conjureReqFrag = document.createDocumentFragment();
+		var conjureReqSpan = document.createElement('span');
+		conjureReqSpan.style.fontWeight = 'bold';
+		conjureReqSpan.className = CM.Disp.colorTextPre + luckyColor;
+		conjureReqSpan.textContent = Beautify(CM.Cache.Conjure);
+		conjureReqFrag.appendChild(conjureReqSpan);
+		if (conjureTime != '') {
+			var conjureReqSmall = document.createElement('small');
+			conjureReqSmall.textContent = ' (' + conjureTime + ')';
+			conjureReqFrag.appendChild(conjureReqSmall);
+		}
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Cookies Required', 'GoldCookTooltipPlaceholder'), conjureReqFrag));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur))));
 	}
 
 	stats.appendChild(header('Chain Cookies', 'Chain'));

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1627,6 +1627,8 @@ CM.Disp.CreateTooltipWarnCaut = function() {
 	}
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipWarn', CM.Disp.colorRed, 'Warning: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!"', 'CMDispTooltipWarnText'));
 	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut2', CM.Disp.colorPurple, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Conjure Baked Goods"', 'CMDispTooltipCaut2Text'));
+	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut', CM.Disp.colorYellow, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!" (Frenzy)', 'CMDispTooltipCautText'));
 
 	l('tooltipAnchor').appendChild(CM.Disp.TooltipWarnCaut);
@@ -1851,8 +1853,9 @@ CM.Disp.UpdateTooltip = function() {
 						warn += ((bonusNoFren * 60 * 15) / 0.15);
 					}
 					var caut = warn * 7;
+					var caut2 = warn * 2;
 					var amount = (Game.cookies + CM.Disp.GetWrinkConfigBank()) - price;
-					if ((amount < warn || amount < caut) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
+					if ((amount < warn || amount < caut2 || amount < caut) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
 						if (CM.Config.ToolWarnCautPos == 0) {
 							CM.Disp.TooltipWarnCaut.style.right = '0px';
 						}
@@ -1864,21 +1867,33 @@ CM.Disp.UpdateTooltip = function() {
 						if (amount < warn) {
 							l('CMDispTooltipWarn').style.display = '';
 							l('CMDispTooltipWarnText').textContent = Beautify(warn - amount) + ' (' + CM.Disp.FormatTime((warn - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipCaut2').style.display = '';
+							l('CMDispTooltipCaut2Text').textContent = Beautify(caut2 - amount) + ' (' + CM.Disp.FormatTime((caut2 - amount) / CM.Disp.GetCPS()) + ')';
 							l('CMDispTooltipCaut').style.display = '';
 							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
+						}
+						else if (amount < caut2) {
+							l('CMDispTooltipCaut2').style.display = '';
+							l('CMDispTooltipCaut2Text').textContent = Beautify(caut2 - amount) + ' (' + CM.Disp.FormatTime((caut2 - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipCaut').style.display = '';
+							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
+							l('CMDispTooltipWarn').style.display = 'none';
 						}
 						else if (amount < caut) {
 							l('CMDispTooltipCaut').style.display = '';
 							l('CMDispTooltipCautText').textContent = Beautify(caut - amount) + ' (' + CM.Disp.FormatTime((caut - amount) / CM.Disp.GetCPS()) + ')';
 							l('CMDispTooltipWarn').style.display = 'none';
+							l('CMDispTooltipCaut2').style.display = 'none';
 						}
 						else {
 							l('CMDispTooltipWarn').style.display = 'none';
+							l('CMDispTooltipCaut2').style.display = 'none';
 							l('CMDispTooltipCaut').style.display = 'none';
 						}
 					}
 					else {
 						l('CMDispTooltipWarn').style.display = 'none';
+						l('CMDispTooltipCaut2').style.display = 'none';
 						l('CMDispTooltipCaut').style.display = 'none';
 					}
 				}
@@ -1889,6 +1904,7 @@ CM.Disp.UpdateTooltip = function() {
 			else { // Grimoire
 				CM.Disp.TooltipWarnCaut.style.display = 'none';
 				l('CMDispTooltipWarn').style.display = 'none';
+				l('CMDispTooltipCaut2').style.display = 'none';
 				l('CMDispTooltipCaut').style.display = 'none';
 
 				var minigame = Game.Objects['Wizard tower'].minigame;
@@ -1944,6 +1960,7 @@ CM.Disp.UpdateTooltip = function() {
 CM.Disp.DrawTooltipWarnCaut = function() {
 	if (CM.Config.ToolWarnCaut == 1) {
 		l('CMDispTooltipWarn').style.opacity = '0';
+		l('CMDispTooltipCaut2').style.opacity = '0';
 		l('CMDispTooltipCaut').style.opacity = '0';
 	}
 }
@@ -1951,6 +1968,7 @@ CM.Disp.DrawTooltipWarnCaut = function() {
 CM.Disp.UpdateTooltipWarnCaut = function() {
 	if (CM.Config.ToolWarnCaut == 1 && l('tooltipAnchor').style.display != 'none' && l('CMTooltipArea') != null) {
 		l('CMDispTooltipWarn').style.opacity = '1';
+		l('CMDispTooltipCaut2').style.opacity = '1';
 		l('CMDispTooltipCaut').style.opacity = '1';
 	}
 }

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1241,6 +1241,45 @@ CM.Disp.AddMenuStats = function(title) {
 		frag.appendChild(span);
 		return frag;
 	}
+	
+	var createMissDisp = function(theMissDisp) {
+		var frag = document.createDocumentFragment();
+		frag.appendChild(document.createTextNode(theMissDisp.length + ' '));
+		var span = document.createElement('span');
+		span.onmouseout = function() { Game.tooltip.hide(); };
+		var placeholder = document.createElement('div');
+		var missing = document.createElement('div');
+		missing.style.minWidth = '140px';
+		missing.style.marginBottom = '4px';
+		var title = document.createElement('div');
+		title.className = 'name';
+		title.style.marginBottom = '4px';
+		title.style.textAlign = 'center';
+		title.textContent = 'Missing';
+		missing.appendChild(title);
+		for (var i in theMissDisp) {
+			var div = document.createElement('div');
+			div.style.textAlign = 'center';
+			div.appendChild(document.createTextNode(theMissDisp[i]));
+			missing.appendChild(div);
+		}
+		placeholder.appendChild(missing);
+		span.onmouseover = function() {Game.tooltip.draw(this, escape(placeholder.innerHTML));};
+		span.style.cursor = 'default';
+		span.style.display = 'inline-block';
+		span.style.height = '10px';
+		span.style.width = '10px';
+		span.style.borderRadius = '5px';
+		span.style.textAlign = 'center';
+		span.style.backgroundColor = '#C0C0C0';
+		span.style.color = 'black';
+		span.style.fontSize = '9px';
+		span.style.verticalAlign = 'bottom';
+		span.textContent = '?';
+		frag.appendChild(span);
+		return frag;
+	}
+
 
 	stats.appendChild(header('Lucky Cookies', 'Lucky'));
 	if (CM.Config.StatsPref.Lucky) {
@@ -1468,48 +1507,11 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(header('Season Specials', 'Sea'));
 		if (CM.Config.StatsPref.Sea) {
 			if (specDisp) {
-				var createSpecDisp = function(theSpecDisp) {
-					var frag = document.createDocumentFragment();
-					frag.appendChild(document.createTextNode(theSpecDisp.length + ' '));
-					var span = document.createElement('span');
-					span.onmouseout = function() { Game.tooltip.hide(); };
-					var placeholder = document.createElement('div');
-					var missing = document.createElement('div');
-					missing.style.minWidth = '140px';
-					missing.style.marginBottom = '4px';
-					var title = document.createElement('div');
-					title.className = 'name';
-					title.style.marginBottom = '4px';
-					title.style.textAlign = 'center';
-					title.textContent = 'Missing';
-					missing.appendChild(title);
-					for (var i in theSpecDisp) {
-						var div = document.createElement('div');
-						div.style.textAlign = 'center';
-						div.appendChild(document.createTextNode(theSpecDisp[i]));
-						missing.appendChild(div);
-					}
-					placeholder.appendChild(missing);
-					span.onmouseover = function() {Game.tooltip.draw(this, escape(placeholder.innerHTML));};
-					span.style.cursor = 'default';
-					span.style.display = 'inline-block';
-					span.style.height = '10px';
-					span.style.width = '10px';
-					span.style.borderRadius = '5px';
-					span.style.textAlign = 'center';
-					span.style.backgroundColor = '#C0C0C0';
-					span.style.color = 'black';
-					span.style.fontSize = '9px';
-					span.style.verticalAlign = 'bottom';
-					span.textContent = '?';
-					frag.appendChild(span);
-					return frag;
-				}
-				if (halloCook.length != 0) stats.appendChild(listing('Halloween Cookies Left to Buy', createSpecDisp(halloCook)));
-				if (christCook.length != 0) stats.appendChild(listing('Christmas Cookies Left to Buy',  createSpecDisp(christCook)));
-				if (valCook.length != 0) stats.appendChild(listing('Valentine Cookies Left to Buy',  createSpecDisp(valCook)));
-				if (normEggs.length != 0) stats.appendChild(listing('Normal Easter Eggs Left to Unlock',  createSpecDisp(normEggs)));
-				if (rareEggs.length != 0) stats.appendChild(listing('Rare Easter Eggs Left to Unlock',  createSpecDisp(rareEggs)));
+				if (halloCook.length != 0) stats.appendChild(listing('Halloween Cookies Left to Buy', createMissDisp(halloCook)));
+				if (christCook.length != 0) stats.appendChild(listing('Christmas Cookies Left to Buy',  createMissDisp(christCook)));
+				if (valCook.length != 0) stats.appendChild(listing('Valentine Cookies Left to Buy',  createMissDisp(valCook)));
+				if (normEggs.length != 0) stats.appendChild(listing('Normal Easter Eggs Left to Unlock',  createMissDisp(normEggs)));
+				if (rareEggs.length != 0) stats.appendChild(listing('Rare Easter Eggs Left to Unlock',  createMissDisp(rareEggs)));
 			}
 
 			if (Game.season == 'christmas') stats.appendChild(listing('Reindeer Reward',  document.createTextNode(Beautify(CM.Cache.SeaSpec))));
@@ -1529,6 +1531,15 @@ CM.Disp.AddMenuStats = function(title) {
 			document.createTextNode(Beautify(CM.Cache.AvgCPS, 3))
 		));
 		stats.appendChild(listing('Average Cookie Clicks Per Second (Past ' + CM.Disp.clickTimes[CM.Config.AvgClicksHist] + (CM.Config.AvgClicksHist == 0 ? ' second' : ' seconds') + ')', document.createTextNode(Beautify(CM.Cache.AvgClicks, 1))));
+		if (Game.Has('Fortune cookies')) {
+			var fortunes = [];
+			for (var i in CM.Data.Fortunes) {
+				if (!Game.Has(CM.Data.Fortunes[i])) {
+					fortunes.push(CM.Data.Fortunes[i]);
+				}
+			}
+			if (fortunes.length != 0) stats.appendChild(listing('Fortune Upgrades Left to Buy',  createMissDisp(fortunes)));
+		}
 		stats.appendChild(listing('Missed Golden Cookies', document.createTextNode(Beautify(Game.missedGoldenClicks))));
 	}
 

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1288,9 +1288,6 @@ CM.Disp.AddMenuStats = function(title) {
 		var luckyColorFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var luckyTimeFrenzy = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.LuckyFrenzy) ? CM.Disp.FormatTime((CM.Cache.LuckyFrenzy - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var luckyCurBase = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 15) + 13;
-		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
-		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
-		var conjureRewardMax = CM.Cache.ConjureReward;
 		var luckyRewardMax = CM.Cache.LuckyReward;
 		var luckyRewardMaxWrath = CM.Cache.LuckyReward;
 		var luckyRewardFrenzyMax = CM.Cache.LuckyRewardFrenzy;
@@ -1341,6 +1338,14 @@ CM.Disp.AddMenuStats = function(title) {
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardMax) + (luckySplit ? (' / ' + Beautify(luckyRewardMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (MAX) (Frenzy)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyRewardFrenzyMax) + (luckySplit ? (' / ' + Beautify(luckyRewardFrenzyMaxWrath)) : ''))));
 		stats.appendChild(listing(listingQuest('\"Lucky!\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur) + (luckySplit ? (' / ' + Beautify(luckyCurWrath)) : ''))));
+	}
+
+	stats.appendChild(header('Conjure Baked Goods', 'Conjure'));
+	if (CM.Config.StatsPref.Conjure) {
+		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
+		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
+		var conjureRewardMax = CM.Cache.ConjureReward;
+
 		var conjureReqFrag = document.createDocumentFragment();
 		var conjureReqSpan = document.createElement('span');
 		conjureReqSpan.style.fontWeight = 'bold';
@@ -1353,8 +1358,8 @@ CM.Disp.AddMenuStats = function(title) {
 			conjureReqFrag.appendChild(conjureReqSmall);
 		}
 		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Cookies Required', 'GoldCookTooltipPlaceholder'), conjureReqFrag));
-		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
-		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)' + (luckySplit ? ' (Golden / Wrath)' : ''), 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(luckyCur))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (MAX)', 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureRewardMax))));
+		stats.appendChild(listing(listingQuest('\"Conjure Baked Goods\" Reward (CUR)', 'GoldCookTooltipPlaceholder'),  document.createTextNode(Beautify(conjureCur))));
 	}
 
 	stats.appendChild(header('Chain Cookies', 'Chain'));

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1342,6 +1342,7 @@ CM.Disp.AddMenuStats = function(title) {
 
 	stats.appendChild(header('Conjure Baked Goods', 'Conjure'));
 	if (CM.Config.StatsPref.Conjure) {
+		var conjureColor = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.colorRed : CM.Disp.colorGreen;
 		var conjureCur = Math.min((Game.cookies + CM.Disp.GetWrinkConfigBank()) * 0.15, CM.Cache.NoGoldSwitchCookiesPS * 60 * 30);
 		var conjureTime = ((Game.cookies + CM.Disp.GetWrinkConfigBank()) < CM.Cache.Conjure) ? CM.Disp.FormatTime((CM.Cache.Conjure - (Game.cookies + CM.Disp.GetWrinkConfigBank())) / CM.Disp.GetCPS()) : '';
 		var conjureRewardMax = CM.Cache.ConjureReward;
@@ -1349,7 +1350,7 @@ CM.Disp.AddMenuStats = function(title) {
 		var conjureReqFrag = document.createDocumentFragment();
 		var conjureReqSpan = document.createElement('span');
 		conjureReqSpan.style.fontWeight = 'bold';
-		conjureReqSpan.className = CM.Disp.colorTextPre + luckyColor;
+		conjureReqSpan.className = CM.Disp.colorTextPre + conjureColor;
 		conjureReqSpan.textContent = Beautify(CM.Cache.Conjure);
 		conjureReqFrag.appendChild(conjureReqSpan);
 		if (conjureTime != '') {
@@ -1648,9 +1649,9 @@ CM.Disp.CreateTooltipWarnCaut = function() {
 		return box;
 	}
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipWarn', CM.Disp.colorRed, 'Warning: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!"', 'CMDispTooltipWarnText'));
-	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.lastChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut2', CM.Disp.colorPurple, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Conjure Baked Goods"', 'CMDispTooltipCaut2Text'));
-	CM.Disp.TooltipWarnCaut.firstChild.style.marginBottom = '4px';
+	CM.Disp.TooltipWarnCaut.lastChild.style.marginBottom = '4px';
 	CM.Disp.TooltipWarnCaut.appendChild(create('CMDispTooltipCaut', CM.Disp.colorYellow, 'Caution: ', 'Purchase of this item will put you under the number of Cookies required for "Lucky!" (Frenzy)', 'CMDispTooltipCautText'));
 
 	l('tooltipAnchor').appendChild(CM.Disp.TooltipWarnCaut);

--- a/src/Main.js
+++ b/src/Main.js
@@ -299,6 +299,6 @@ CM.ConfigDefault = {
 };
 CM.ConfigPrefix = 'CMConfig';
 
-CM.VersionMajor = '2.022';
+CM.VersionMajor = '2.029';
 CM.VersionMinor = '1';
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -294,7 +294,7 @@ CM.ConfigDefault = {
 	SayTime: 1, 
 	GrimoireBar: 1, 
 	Scale: 2, 
-	StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1}, 
+	StatsPref: {Lucky: 1, Chain: 1, Prestige: 1, Wrink: 1, Sea: 1, Misc: 1, Conjure: 1}, 
 	Colors : {Blue: '#4bb8f0', Green: '#00ff00', Yellow: '#ffff00', Orange: '#ff7f00', Red: '#ff0000', Purple: '#ff00ff', Gray: '#b3b3b3', Pink: '#ff1493', Brown: '#8b4513'}
 };
 CM.ConfigPrefix = 'CMConfig';

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -219,6 +219,7 @@ CM.Sim.CalculateGains = function() {
 
 	if (CM.Sim.Has('Fortune #100')) mult *= 1.01;
 	if (CM.Sim.Has('Fortune #101')) mult *= 1.07;
+	if (CM.Sim.Has('Dragon scale')) mult *= 1.03;
 
 	var buildMult = 1;
 	if (Game.hasGod) {
@@ -402,6 +403,7 @@ CM.Sim.CheckOtherAchiev = function() {
 	if (minAmount >= 400) CM.Sim.Win('Quadricentennial');
 	if (minAmount >= 450) CM.Sim.Win('Quadricentennial and a half');
 	if (minAmount >= 500) CM.Sim.Win('Quincentennial');
+	if (minAmount >= 550) CM.Sim.Win('Quincentennial and a half');
 
 	if (buildingsOwned >= 100) CM.Sim.Win('Builder');
 	if (buildingsOwned >= 500) CM.Sim.Win('Architect');
@@ -457,6 +459,7 @@ CM.Sim.BuyBuildings = function(amount, target) {
 			if (me.amount >= 400) CM.Sim.Win('Dr. T');
 			if (me.amount >= 500) CM.Sim.Win('Thumbs, phalanges, metacarpals');
 			if (me.amount >= 600) CM.Sim.Win('With her finger and her thumb');
+			if (me.amount >= 700) CM.Sim.Win('Gotta hand it to you');
 		}
 		else {
 			for (var j in Game.Objects[me.name].tieredAchievs) {


### PR DESCRIPTION
I did some research into the Conjure Baked Goods Spell and realised that the maximum value you can get from the Spell is higher then the max Lucky Reward.
So I added a Tooltip and a Statblock for "Conjure Baked Goods Spell"

If you want to try it out yourself: 
`javascript:(function() {    Game.LoadMod('https://michiocre.github.io/CookieMonster/CookieMonster.js');}());`

![image](https://user-images.githubusercontent.com/7807995/97006431-29e69680-1540-11eb-87f7-2893301bd53d.png)
All the tooltips at once

![image](https://user-images.githubusercontent.com/7807995/97006482-3d91fd00-1540-11eb-9af0-144a2c27329f.png)
The two warning tooltips

![image](https://user-images.githubusercontent.com/7807995/97006554-56021780-1540-11eb-8910-3384a1679343.png)
Only the frenzy Lucky tooltip

![image](https://user-images.githubusercontent.com/7807995/97006611-6914e780-1540-11eb-874a-73c56f81f58c.png)
The "Conjure Baked Goods" statblock

![image](https://user-images.githubusercontent.com/7807995/97006692-847ff280-1540-11eb-8df8-56e6854fabb8.png)
The "Conjured Baked Goods" statblock when the max reward is not ready