### PR TITLE
Revert "Extend metric unit prefixes"

### DIFF
--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2133,7 +2133,7 @@ CM.Disp.lastAscendState = -1;
 CM.Disp.cookieTimes = [10, 15, 30, 60, 300, 600, 900, 1800];
 CM.Disp.clickTimes = [1, 5, 10, 15, 30];
 
-CM.Disp.metric = ['M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'KY', 'MY', 'GY', 'TY', 'PY', 'EY', 'ZY', 'YY', 'KYY', 'MYY', 'GYY', 'TYY', 'PYY', 'EYY', 'ZYY', 'YYY'];
+CM.Disp.metric = ['M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
 CM.Disp.shortScale = ['M', 'B', 'Tr', 'Quadr', 'Quint', 'Sext', 'Sept', 'Oct', 'Non', 'Dec', 'Undec', 'Duodec', 'Tredec', 'Quattuordec', 'Quindec', 'Sexdec', 'Septendec', 'Octodec', 'Novemdec', 'Vigint', 'Unvigint', 'Duovigint', 'Trevigint', 'Quattuorvigint'];
 
 CM.Disp.TooltipWrinklerArea = 0;


### PR DESCRIPTION
Reverts Aktanusa/CookieMonster#285

Current PR only updates src/Disp.js
It should also be added to CookieMonster.js, preferably by using the Combine command given in the main directory.