### PR TITLE
Fix Conjure Baked Goods warning not disappearing

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2786,6 +2786,8 @@ CM.Disp.UpdateTooltip = function() {
 					if ((amount < limitConjure) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
 						l('CMDispTooltipWarnConjure').style.display = '';
 						l('CMDispTooltipWarnConjureText').textContent = Beautify(limitConjure - amount) + ' (' + CM.Disp.FormatTime((limitConjure - amount) / CM.Disp.GetCPS()) + ')';
+					} else {
+						l('CMDispTooltipWarnConjure').style.display = 'none';
 					}
 				}
 				else {

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2114,6 +2114,8 @@ CM.Disp.UpdateTooltip = function() {
 					if ((amount < limitConjure) && (CM.Disp.tooltipType != 'b' || Game.buyMode == 1)) {
 						l('CMDispTooltipWarnConjure').style.display = '';
 						l('CMDispTooltipWarnConjureText').textContent = Beautify(limitConjure - amount) + ' (' + CM.Disp.FormatTime((limitConjure - amount) / CM.Disp.GetCPS()) + ')';
+					} else {
+						l('CMDispTooltipWarnConjure').style.display = 'none';
 					}
 				}
 				else {


### PR DESCRIPTION
The current dev branch doesn't allow the Conjure Baked Goods warning to disappear when hovering over another building/upgrade for which it isn't needed. This patch fixes the issue.