### PR TITLE
 Compute stock market goods in chocolate egg value

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -262,6 +262,16 @@ CM.Cache.RemakeSellForChoEgg = function() {
 			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, amount, me.free, amount, 1);
 		}
 	}
+	// Compute cookies earned by selling stock market goods
+	if (Game.Objects.Bank.minigameLoaded) {
+		var marketGoods = Game.Objects.Bank.minigame.goods;
+		var goodsVal = 0;
+		for (var i in marketGoods) {
+			var marketGood = marketGoods[i];
+			goodsVal += marketGood.stock * marketGood.val;
+		}
+		sellTotal += goodsVal * Game.cookiesPsRawHighest;
+	}
 	CM.Cache.SellForChoEgg = sellTotal;
 }
 
@@ -3041,7 +3051,7 @@ CM.Disp.TooltipText = [
 	['NextPrestTooltipPlaceholder', 'Calculated with cookies gained from wrinklers and Chocolate egg', '200px'], 
 	['HeavenChipMaxTooltipPlaceholder', 'The MAX heavenly chips is calculated with the cookies gained from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, and buying Chocolate egg', '330px'], 
 	['ResetTooltipPlaceholder', 'The bonus income you would get from new prestige levels unlocked at 100% of its potential and from reset achievements if you have the same buildings/upgrades after reset', '370px'], 
-	['ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, and then buying Chocolate egg', '300px']
+	['ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, selling all stock market goods, and then buying Chocolate egg', '300px']
 ];
 /********
  * Main *

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -242,6 +242,16 @@ CM.Cache.RemakeSellForChoEgg = function() {
 			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, amount, me.free, amount, 1);
 		}
 	}
+	// Compute cookies earned by selling stock market goods
+	if (Game.Objects.Bank.minigameLoaded) {
+		var marketGoods = Game.Objects.Bank.minigame.goods;
+		var goodsVal = 0;
+		for (var i in marketGoods) {
+			var marketGood = marketGoods[i];
+			goodsVal += marketGood.stock * marketGood.val;
+		}
+		sellTotal += goodsVal * Game.cookiesPsRawHighest;
+	}
 	CM.Cache.SellForChoEgg = sellTotal;
 }
 

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2369,5 +2369,5 @@ CM.Disp.TooltipText = [
 	['NextPrestTooltipPlaceholder', 'Calculated with cookies gained from wrinklers and Chocolate egg', '200px'], 
 	['HeavenChipMaxTooltipPlaceholder', 'The MAX heavenly chips is calculated with the cookies gained from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, and buying Chocolate egg', '330px'], 
 	['ResetTooltipPlaceholder', 'The bonus income you would get from new prestige levels unlocked at 100% of its potential and from reset achievements if you have the same buildings/upgrades after reset', '370px'], 
-	['ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, and then buying Chocolate egg', '300px']
+	['ChoEggTooltipPlaceholder', 'The amount of cookies you would get from popping all wrinklers with Skruuia god in Diamond slot, selling all buildings with Earth Shatterer and Reality Bending auras, selling all stock market goods, and then buying Chocolate egg', '300px']
 ];


### PR DESCRIPTION
Update the cache method `RemakeSellForChoEgg` to handle the stock market goods value in the `SellForChoEgg ` cache variable, used in chocolate egg value computation.

---

This closes #305 