### PR TITLE
Fix buildings value in chocolate egg calculation

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -286,43 +286,7 @@ CM.Cache.RemakeSeaSpec = function() {
 }
 
 CM.Cache.RemakeSellForChoEgg = function() {
-	if (Game.auraMult('Earth Shatterer') == 1.1) {
-		var sellTotal = 0;
-		for (var i in Game.Objects) {
-			var me = Game.Objects[i];
-			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, me.amount, me.free, me.amount, 0);
-		}
-	}
-	else {
-		var highestBuilding = '';
-		for (var i in Game.Objects) {
-			if (Game.Objects[i].amount > 0) highestBuilding = i;
-		}
-		var secondHighBuild = '';
-		if (Game.auraMult('Earth Shatterer') == 0 && highestBuilding != '') {
-			if (Game.Objects[highestBuilding].amount > 1) {
-				secondHighBuild = highestBuilding;
-			}
-			else {
-				for (var i in Game.Objects) {
-					if (i != highestBuilding && Game.Objects[i].amount > 0) secondHighBuild = i;
-				}
-			}
-		}
-		
-		var sellTotal = 0;
-		for (var i in Game.Objects) {
-			var me = Game.Objects[i];
-			var amount = me.amount;
-			if (i == highestBuilding) {
-				amount -= 1;
-			}
-			if (i == secondHighBuild) {
-				amount -= 1;
-			}
-			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, amount, me.free, amount, 1);
-		}
-	}
+	var sellTotal = 0;
 	// Compute cookies earned by selling stock market goods
 	if (Game.Objects.Bank.minigameLoaded) {
 		var marketGoods = Game.Objects.Bank.minigame.goods;
@@ -333,6 +297,8 @@ CM.Cache.RemakeSellForChoEgg = function() {
 		}
 		sellTotal += goodsVal * Game.cookiesPsRawHighest;
 	}
+	// Compute cookies earned by selling all buildings with optimal auras (ES + RB)
+	sellTotal += CM.Sim.SellBuildingsForChoEgg();
 	CM.Cache.SellForChoEgg = sellTotal;
 }
 
@@ -2756,10 +2722,10 @@ CM.Disp.Tooltip = function(type, name) {
 		}
 		else if (Game.buyMode == -1) {
 			if (Game.buyBulk == -1) {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.Objects[name].amount, 0)));
+				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.Objects[name].amount)));
 			}
 			else {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk, 0)));
+				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk)));
 			}
 		}
 	}
@@ -3550,7 +3516,7 @@ CM.Sim.BuildingGetPrice = function(build, basePrice, start, free, increase) {
 	return moni;
 }
 
-CM.Sim.BuildingSell = function(build, basePrice, start, free, amount, emuAura) {
+CM.Sim.BuildingSell = function(build, basePrice, start, free, amount) {
 	/*var price=0;
 	for (var i = Math.max(0, start - amount); i < Math.max(0, start); i++) {
 		price += basePrice * Math.pow(Game.priceIncrease, Math.max(0, i - free));
@@ -3568,18 +3534,13 @@ CM.Sim.BuildingSell = function(build, basePrice, start, free, amount, emuAura) {
 	}
 	return Math.ceil(price);*/
 
-	var moni=0;
+	// Calculate money gains from selling buildings
+	var moni = 0;
 	for (var i = 0; i < amount; i++) {
 		var price = basePrice * Math.pow(Game.priceIncrease, Math.max(0, start - free));
-		price = Game.modifyBuildingPrice(build, price);
+		price = CM.Sim.modifyBuildingPrice(build, price);
 		price = Math.ceil(price);
-		var giveBack = 0.25;
-		if (emuAura) {
-			giveBack = 0.5;
-		}
-		else {
-			giveBack *= 1 + Game.auraMult('Earth Shatterer');
-		}
+		var giveBack = CM.Sim.getSellMultiplier();
 		price = Math.floor(price * giveBack);
 		if (start > 0) {
 			moni += price;
@@ -4145,6 +4106,80 @@ CM.Sim.ResetBonus = function(possiblePresMax) {
 	return (CM.Sim.cookiesPs - curCPS);
 }
 
+CM.Sim.getSellMultiplier = function() {
+	var giveBack = 0.25;
+	giveBack *= 1 + CM.Sim.auraMult('Earth Shatterer');
+	return giveBack;
+}
+
+CM.Sim.modifyBuildingPrice = function(building,price) {	
+	if (CM.Sim.Has('Season savings')) price *= 0.99;
+	if (CM.Sim.Has('Santa\'s dominion')) price *= 0.99;
+	if (CM.Sim.Has('Faberge egg')) price *= 0.99;
+	if (CM.Sim.Has('Divine discount')) price *= 0.99;
+	if (CM.Sim.Has('Fortune #100')) price *= 0.99;
+	//if (CM.Sim.hasAura('Fierce Hoarder')) price *= 0.98;
+	price *= 1 - CM.Sim.auraMult('Fierce Hoarder') * 0.02;
+	if (Game.hasBuff('Everything must go')) price *= 0.95;
+	if (Game.hasBuff('Crafty pixies')) price *= 0.98;
+	if (Game.hasBuff('Nasty goblins')) price *= 1.02;
+	if (building.fortune && CM.Sim.Has(building.fortune.name)) price *= 0.93;
+	price *= Game.eff('buildingCost');
+	if (Game.hasGod) {
+		var godLvl = Game.hasGod('creation');
+		if (godLvl == 1) price *= 0.93;
+		else if (godLvl == 2) price *= 0.95;
+		else if (godLvl == 3) price *= 0.98;
+	}
+	return price;
+}
+
+CM.Sim.SellBuildingsForChoEgg = function() {
+	var sellTotal = 0;
+
+	CM.Sim.CopyData();
+	
+	// Change auras to Earth Shatterer + Reality bending to optimize money made by selling
+	var buildingsToSacrifice = 2;
+	if (CM.Sim.dragonAura === 5 || CM.Sim.dragonAura === 18) {
+		--buildingsToSacrifice;
+	}
+	if (CM.Sim.dragonAura2 === 5 || CM.Sim.dragonAura2 === 18) {
+		--buildingsToSacrifice;
+	}
+	CM.Sim.dragonAura = 5;
+	CM.Sim.dragonAura2 = 18;
+	// Sacrifice highest buildings for the aura switch
+	for (var i = 0; i < buildingsToSacrifice; ++i) {
+		var highestBuilding = 0;
+		for (var j in CM.Sim.Objects) {
+			if (CM.Sim.Objects[j].amount > 0) {	
+				highestBuilding = CM.Sim.Objects[j];
+			}
+		}
+		highestBuilding.amount--;
+		CM.Sim.buildingsOwned--;
+	}
+
+	// Get money made by selling all remaining buildings
+	for (var i in CM.Sim.Objects) {
+		var me = CM.Sim.Objects[i];
+		debug = CM.Sim.BuildingSell(Game.Objects[me.name], Game.Objects[i].basePrice, me.amount, Game.Objects[i].free, me.amount);
+		sellTotal += debug;
+	}
+
+	// CM.Sim.CalculateGains();
+
+	// CM.Sim.CheckOtherAchiev();
+
+	// if (lastAchievementsOwned != CM.Sim.AchievementsOwned) {
+	// 	CM.Sim.CalculateGains();
+	// }
+
+	// CM.Cache.DoRemakeBuildPrices = 1;
+
+	return sellTotal;
+}
 /**********
  * Footer *
  **********/

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -266,43 +266,7 @@ CM.Cache.RemakeSeaSpec = function() {
 }
 
 CM.Cache.RemakeSellForChoEgg = function() {
-	if (Game.auraMult('Earth Shatterer') == 1.1) {
-		var sellTotal = 0;
-		for (var i in Game.Objects) {
-			var me = Game.Objects[i];
-			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, me.amount, me.free, me.amount, 0);
-		}
-	}
-	else {
-		var highestBuilding = '';
-		for (var i in Game.Objects) {
-			if (Game.Objects[i].amount > 0) highestBuilding = i;
-		}
-		var secondHighBuild = '';
-		if (Game.auraMult('Earth Shatterer') == 0 && highestBuilding != '') {
-			if (Game.Objects[highestBuilding].amount > 1) {
-				secondHighBuild = highestBuilding;
-			}
-			else {
-				for (var i in Game.Objects) {
-					if (i != highestBuilding && Game.Objects[i].amount > 0) secondHighBuild = i;
-				}
-			}
-		}
-		
-		var sellTotal = 0;
-		for (var i in Game.Objects) {
-			var me = Game.Objects[i];
-			var amount = me.amount;
-			if (i == highestBuilding) {
-				amount -= 1;
-			}
-			if (i == secondHighBuild) {
-				amount -= 1;
-			}
-			sellTotal += CM.Sim.BuildingSell(me, me.basePrice, amount, me.free, amount, 1);
-		}
-	}
+	var sellTotal = 0;
 	// Compute cookies earned by selling stock market goods
 	if (Game.Objects.Bank.minigameLoaded) {
 		var marketGoods = Game.Objects.Bank.minigame.goods;
@@ -313,6 +277,8 @@ CM.Cache.RemakeSellForChoEgg = function() {
 		}
 		sellTotal += goodsVal * Game.cookiesPsRawHighest;
 	}
+	// Compute cookies earned by selling all buildings with optimal auras (ES + RB)
+	sellTotal += CM.Sim.SellBuildingsForChoEgg();
 	CM.Cache.SellForChoEgg = sellTotal;
 }
 

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1996,10 +1996,10 @@ CM.Disp.Tooltip = function(type, name) {
 		}
 		else if (Game.buyMode == -1) {
 			if (Game.buyBulk == -1) {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.Objects[name].amount, 0)));
+				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.Objects[name].amount)));
 			}
 			else {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk, 0)));
+				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk)));
 			}
 		}
 	}


### PR DESCRIPTION
Fix the calculated buildings value in chocolate egg by adding a sim version of `modifyBuildingPrice` method, allowing for proper simulation of the cookies earned by selling all buildings under the best dragon auras (Earth Shatterer + Reality Bending).

# Approach

The method `CM.Cache.RemakeSellForChoEgg` calculating the chocolate egg value `CM.Cache.SellForChoEgg` calls the method `CM.Sim.BuildingSell` to get the cokies earned when a building is sold. However, this method `CM.Sim.BuildingSell` had 2 problems leading to the calculated value being incorrect:
- it wasn't properly simulating the Reality Bending aura, only Earth Shatterer;
- it was based on the `Game.modifyBuildingPrice` method to calculate buildings value, which includes a multiplier that depends on an aura (Fierce Hoarder), leading to a difference between expected auras and calculated ones.

## Changes in the chocolate egg calculation method

To fix this, I've moved the code computing building selling values to a dedicated simulation method `CM.Sim.SellBuildingsForChoEgg` which creates a simulation that:
1. Changes the aura to Earth Shatterer + Reality Bending if necessary (and sacrifices the required buildings);
2. Calculates the cookies earned for selling all the remaining buildings.

## Other methods added for the simulation

To get the good simulated values instead of the current Game ones, I've added these methods:
- `CM.Sim.getSellMultiplier` based on `Game.object.getSellMultiplier`;
- `CM.Sim.modifyBuildingPrice` base on `Game.modifyBuildingPrice`.

---

This closes #347 