### PR TITLE
Fix building price displayed in sell mode

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -1424,7 +1424,17 @@ CM.Disp.UpdateBuildings = function() {
 	}
 	else {
 		for (var i in CM.Cache.Objects) {
-			l('productPrice' + Game.Objects[i].id).style.color = '';
+			var o = Game.Objects[i];
+			l('productPrice' + o.id).style.color = '';
+			/*
+			 * Fix sell price displayed in the object in the store.
+			 *
+			 * The buildings sell price displayed by the game itself (without any mod) is incorrect.
+			 * The following line of code fixes this issue, and can be safely removed when the game gets fixed.
+			 * 
+			 * This issue is extensively detailed here: https://github.com/Aktanusa/CookieMonster/issues/359#issuecomment-735658262
+			 */
+			l('productPrice' + o.id).innerHTML = Beautify(CM.Sim.BuildingSell(o, o.basePrice, o.amount, o.free, Game.buyBulk, 1));
 		}
 	}
 	

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -2079,12 +2079,15 @@ CM.Disp.Tooltip = function(type, name) {
 			}
 		}
 		else if (Game.buyMode == -1) {
-			if (Game.buyBulk == -1) {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.Objects[name].amount)));
-			}
-			else {
-				l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].getPrice())).join('-' + Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk)));
-			}
+			/*
+			 * Fix sell price displayed in the object tooltip.
+			 *
+			 * The buildings sell price displayed by the game itself (without any mod) is incorrect.
+			 * The following line of code fixes this issue, and can be safely removed when the game gets fixed.
+			 * 
+			 * This issue is extensively detailed here: https://github.com/Aktanusa/CookieMonster/issues/359#issuecomment-735658262
+			 */
+			l('tooltip').innerHTML = l('tooltip').innerHTML.split(Beautify(Game.Objects[name].bulkPrice)).join(Beautify(CM.Sim.BuildingSell(Game.Objects[name], Game.Objects[name].basePrice, Game.Objects[name].amount, Game.Objects[name].free, Game.buyBulk, 1)));
 		}
 	}
 	else if (type == 'u') {

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -676,7 +676,17 @@ CM.Disp.UpdateBuildings = function() {
 	}
 	else {
 		for (var i in CM.Cache.Objects) {
-			l('productPrice' + Game.Objects[i].id).style.color = '';
+			var o = Game.Objects[i];
+			l('productPrice' + o.id).style.color = '';
+			/*
+			 * Fix sell price displayed in the object in the store.
+			 *
+			 * The buildings sell price displayed by the game itself (without any mod) is incorrect.
+			 * The following line of code fixes this issue, and can be safely removed when the game gets fixed.
+			 * 
+			 * This issue is extensively detailed here: https://github.com/Aktanusa/CookieMonster/issues/359#issuecomment-735658262
+			 */
+			l('productPrice' + o.id).innerHTML = Beautify(CM.Sim.BuildingSell(o, o.basePrice, o.amount, o.free, Game.buyBulk, 1));
 		}
 	}
 	

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -25,7 +25,7 @@ CM.Sim.BuildingGetPrice = function(build, basePrice, start, free, increase) {
 	return moni;
 }
 
-CM.Sim.BuildingSell = function(build, basePrice, start, free, amount) {
+CM.Sim.BuildingSell = function(build, basePrice, start, free, amount, noSim) {
 	/*var price=0;
 	for (var i = Math.max(0, start - amount); i < Math.max(0, start); i++) {
 		price += basePrice * Math.pow(Game.priceIncrease, Math.max(0, i - free));
@@ -44,12 +44,16 @@ CM.Sim.BuildingSell = function(build, basePrice, start, free, amount) {
 	return Math.ceil(price);*/
 
 	// Calculate money gains from selling buildings
+	// If noSim is set, use Game methods to compute price instead of Sim ones.
+	noSim = typeof noSim === "undefined" ? 0 : noSim;
 	var moni = 0;
+	if (amount == -1) amount = start;
+	if (!amount) amount = Game.buyBulk;
 	for (var i = 0; i < amount; i++) {
 		var price = basePrice * Math.pow(Game.priceIncrease, Math.max(0, start - free));
-		price = CM.Sim.modifyBuildingPrice(build, price);
+		price = noSim ? Game.modifyBuildingPrice(build, price) : CM.Sim.modifyBuildingPrice(build, price);
 		price = Math.ceil(price);
-		var giveBack = CM.Sim.getSellMultiplier();
+		var giveBack = noSim ? build.getSellMultiplier() : CM.Sim.getSellMultiplier();
 		price = Math.floor(price * giveBack);
 		if (start > 0) {
 			moni += price;


### PR DESCRIPTION
This fix changes the building price displayed in both object tooltip and in the store.

To do so, it adds an optional parameter `noSim` to `CM.Sim.BuildingSell` to allow for building price calculation while taking the current Game multipliers instead of the CM.Sim ones. Basically, it acts as a reversed version of the old `emuAura` removed in #355 .

This closes #359 