### PR TITLE
Hotfix Dragon's Fortune mult in CM.Sim.CalculateGains

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -4248,13 +4248,12 @@ CM.Sim.CalculateGains = function() {
 		if (rawCookiesPs >= Game.CpsAchievements[i].threshold) CM.Sim.Win(Game.CpsAchievements[i].name);
 	}
 
-	CM.Sim.cookiesPsRaw=rawCookiesPs;
+	CM.Sim.cookiesPsRaw = rawCookiesPs;	
 
-	if (CM.Sim.hasAura('Dragon\'s Fortune')) {
-		var n = Game.shimmerTypes['golden'].n;
-		for (var i = 0; i < n; i++) {
-			mult *= 1.23;
-		}
+	var n = Game.shimmerTypes['golden'].n;
+	var auraMult = CM.Sim.auraMult('Dragon\'s Fortune');
+	for (var i = 0; i < n; i++){
+		mult *= 1 + auraMult * 1.23;
 	}
 
 	var name = Game.bakeryName.toLowerCase();

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -408,13 +408,12 @@ CM.Sim.CalculateGains = function() {
 		if (rawCookiesPs >= Game.CpsAchievements[i].threshold) CM.Sim.Win(Game.CpsAchievements[i].name);
 	}
 
-	CM.Sim.cookiesPsRaw=rawCookiesPs;
+	CM.Sim.cookiesPsRaw = rawCookiesPs;	
 
-	if (CM.Sim.hasAura('Dragon\'s Fortune')) {
-		var n = Game.shimmerTypes['golden'].n;
-		for (var i = 0; i < n; i++) {
-			mult *= 1.23;
-		}
+	var n = Game.shimmerTypes['golden'].n;
+	var auraMult = CM.Sim.auraMult('Dragon\'s Fortune');
+	for (var i = 0; i < n; i++){
+		mult *= 1 + auraMult * 1.23;
 	}
 
 	var name = Game.bakeryName.toLowerCase();


### PR DESCRIPTION
Fix the mult for Dragon's Fortune aura in `CM.Sim.CalculateGains`, which was not calculated properly with the Reality Bending aura.

This should also be merged in `dev` (I'll create another PR). This closes #426