### PR TITLE
Added extra info to dragon aura selector display

### DIFF
--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -4280,7 +4280,8 @@ CM.Sim.getCPSBuffMult = function() {
 	return mult;
 }
 
-/* Constructs an object with the static properties of a building,
+/**
+ * Constructs an object with the static properties of a building,
  * but with a 'cps' method changed to use 'CM.Sim.Has' instead of 'Game.Has'
  * (and similar to 'hasAura', 'Objects', 'GetTieredCpsMult' and 'auraMult').
  *
@@ -4304,7 +4305,8 @@ CM.Sim.InitialBuildingData = function(buildingName) {
 	return you;
 }
 
-/* Similar to the previous function, but for upgrades.
+/**
+ *  Similar to the previous function, but for upgrades.
  * Note: currently no static data is used by Cookie Monster,
  * so this function just returns an empty object.
  */
@@ -4316,7 +4318,8 @@ CM.Sim.InitUpgrade = function(upgradeName) {
 	return you;
 }
 
-/* Similar to the previous function, but for achievements.
+/**
+ * Similar to the previous function, but for achievements.
  * Note: currently no static data is used by Cookie Monster,
  * so this function just returns an empty object.
  */

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -874,6 +874,7 @@ CM.ConfigData.ToolWarnPos = {type: 'bool', group: 'Tooltip', label: ['Tooltip Wa
 CM.ConfigData.TooltipGrim = {type: 'bool', group: 'Tooltip', label: ['Grimoire Tooltip Information OFF', 'Grimoire Tooltip Information ON'], desc: 'Extra information in tooltip for grimoire', toggle: true};
 CM.ConfigData.ToolWrink = {type: 'bool', group: 'Tooltip', label: ['Wrinkler Tooltip OFF', 'Wrinkler Tooltip ON'], desc: 'Shows the amount of cookies a wrinkler will give when popping it', toggle: true};
 CM.ConfigData.TooltipLump = {type: 'bool', group: 'Tooltip', label: ['Sugar Lump Tooltip OFF', 'Sugar Lump Tooltip ON'], desc: 'Shows the current Sugar Lump type in Sugar lump tooltip.', toggle: true};
+CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura OFF', 'Extra Dragon Aura ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
 
 // Statistics
 CM.ConfigData.Stats = {type: 'bool', group: 'Statistics', label: ['Statistics OFF', 'Statistics ON'], desc: 'Extra Cookie Monster statistics!', toggle: true};
@@ -2655,6 +2656,17 @@ CM.Disp.UpdateWrinklerTooltip = function() {
 }
 
 /********
+ * Section: Functions related to the dragon aura interface */
+
+CM.Disp.AddAuraInfo = function() {
+	if (CM.Config.DragonAuraInfo == 1) {
+		console.log("Yes!")
+	} else {
+		console.log("No!")
+	}
+}
+
+/********
  * Section: General functions related to the Options/Stats pages
 
 /**
@@ -3608,6 +3620,18 @@ CM.ReplaceNative = function() {
 		Game.CalculateGains();
 	}
 
+	
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura;
+	/**
+	 * This functions adds the function CM.Disp.AddAuraInfo() to Game.DescribeDragonAura()
+	 * This adds information about CPS differences and costs to the aura choosing interface
+	 * @param	{number}	aura	The number of the aura current selected by the mouse/user
+	 */
+	Game.DescribeDragonAura = function(aura) {
+		CM.Backup.DescribeDragonAura(aura);
+		CM.Disp.AddAuraInfo();
+	}
+
 	CM.Backup.UpdateMenu = Game.UpdateMenu;
 	Game.UpdateMenu = function() {
 		if (typeof jscolor.picker === 'undefined' || typeof jscolor.picker.owner === 'undefined') {
@@ -4081,6 +4105,7 @@ CM.ConfigDefault = {
 	TooltipGrim:1, 
 	ToolWrink: 1, 
 	TooltipLump: 1,
+	DragonAuraInfo: 1,
 	Stats: 1, 
 	MissingUpgrades: 0,
 	UpStats: 1, 

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -889,7 +889,7 @@ CM.ConfigData.ToolWarnPos = {type: 'bool', group: 'Tooltip', label: ['Tooltip Wa
 CM.ConfigData.TooltipGrim = {type: 'bool', group: 'Tooltip', label: ['Grimoire Tooltip Information OFF', 'Grimoire Tooltip Information ON'], desc: 'Extra information in tooltip for grimoire', toggle: true};
 CM.ConfigData.ToolWrink = {type: 'bool', group: 'Tooltip', label: ['Wrinkler Tooltip OFF', 'Wrinkler Tooltip ON'], desc: 'Shows the amount of cookies a wrinkler will give when popping it', toggle: true};
 CM.ConfigData.TooltipLump = {type: 'bool', group: 'Tooltip', label: ['Sugar Lump Tooltip OFF', 'Sugar Lump Tooltip ON'], desc: 'Shows the current Sugar Lump type in Sugar lump tooltip.', toggle: true};
-CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura OFF', 'Extra Dragon Aura ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
+CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura Info OFF', 'Extra Dragon Aura Info ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
 
 // Statistics
 CM.ConfigData.Stats = {type: 'bool', group: 'Statistics', label: ['Statistics OFF', 'Statistics ON'], desc: 'Extra Cookie Monster statistics!', toggle: true};

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -2657,12 +2657,24 @@ CM.Disp.UpdateWrinklerTooltip = function() {
 
 /********
  * Section: Functions related to the dragon aura interface */
-
+/**
+ * This functions adds the two extra lines about CPS and time to recover to the aura picker infoscreen
+ * This adds information about CPS differences and costs to the aura choosing interface
+ * @param	{number}	aura	The number of the aura currently selected by the mouse/user
+ */
 CM.Disp.AddAuraInfo = function() {
 	if (CM.Config.DragonAuraInfo == 1) {
-		console.log("Yes!")
-	} else {
-		console.log("No!")
+		console.log("called")
+		var bonusCPS = "TESTCPS";
+		var bonusCPSPercentage = "TESTCPS%";
+		var timeToRecover = "TESTTIME";
+		l('dragonAuraInfo').style.minHeight = "90px"
+		l('dragonAuraInfo').appendChild(document.createElement("div")).className = "line"
+		var div = document.createElement("div");
+		div.style.minWidth = "200px";
+		div.style.textAlign = "center";
+		div.textContent = "Picking this aura will change CPS by " + bonusCPS + " (" + bonusCPSPercentage + "% of current cps). It will take " + timeToRecover + " to recover the cost.";
+		l('dragonAuraInfo').appendChild(div);
 	}
 }
 
@@ -3625,11 +3637,11 @@ CM.ReplaceNative = function() {
 	/**
 	 * This functions adds the function CM.Disp.AddAuraInfo() to Game.DescribeDragonAura()
 	 * This adds information about CPS differences and costs to the aura choosing interface
-	 * @param	{number}	aura	The number of the aura current selected by the mouse/user
+	 * @param	{number}	aura	The number of the aura currently selected by the mouse/user
 	 */
 	Game.DescribeDragonAura = function(aura) {
 		CM.Backup.DescribeDragonAura(aura);
-		CM.Disp.AddAuraInfo();
+		CM.Disp.AddAuraInfo(aura);
 	}
 
 	CM.Backup.UpdateMenu = Game.UpdateMenu;

--- a/CookieMonster.js
+++ b/CookieMonster.js
@@ -4789,6 +4789,12 @@ CM.Sim.BuyUpgrades = function() {
 	}
 }
 
+/**
+ * This functions calculates the cps and cost of changing a Dragon Aura
+ * It is called by CM.Disp.AddAuraInfo()
+ * @param	{number}			aura										The number of the aura currently selected by the mouse/user
+ * @returns {[number, number]} 	[CM.Sim.cookiesPs - Game.cookiesPs, price]	The bonus cps and the price of the change
+ */
 CM.Sim.CalculateChangeAura = function(aura) {
 	CM.Sim.CopyData();
 

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -2,6 +2,16 @@
  * Cache *
  *********/
 
+/**
+ * This functions caches the currently selected Dragon Auras
+ * It is called by CM.Sim.CopyData() and CM.Sim.InitData()
+ * Uncapitalized dragon follows Game-naming
+ */
+CM.Cache.CacheDragonAuras = function() {
+	CM.Cache.dragonAura = Game.dragonAura;
+	CM.Cache.dragonAura2 = Game.dragonAura2;
+}
+
 /********
  * Section: UNSORTED */
 
@@ -530,3 +540,9 @@ CM.Cache.MissingCookiesString = null;
 CM.Cache.seasonPopShimmer;
 CM.Cache.goldenShimmersByID = {};
 CM.Cache.spawnedGoldenShimmer = 0;
+
+/**
+ * This variables are used by CM.Cache.CacheDragonAuras(), naming follows naming in Game
+ */
+CM.Cache.dragonAura = 0;
+CM.Cache.dragonAura2 = 0;

--- a/src/Data.js
+++ b/src/Data.js
@@ -162,6 +162,7 @@ CM.ConfigData.ToolWarnPos = {type: 'bool', group: 'Tooltip', label: ['Tooltip Wa
 CM.ConfigData.TooltipGrim = {type: 'bool', group: 'Tooltip', label: ['Grimoire Tooltip Information OFF', 'Grimoire Tooltip Information ON'], desc: 'Extra information in tooltip for grimoire', toggle: true};
 CM.ConfigData.ToolWrink = {type: 'bool', group: 'Tooltip', label: ['Wrinkler Tooltip OFF', 'Wrinkler Tooltip ON'], desc: 'Shows the amount of cookies a wrinkler will give when popping it', toggle: true};
 CM.ConfigData.TooltipLump = {type: 'bool', group: 'Tooltip', label: ['Sugar Lump Tooltip OFF', 'Sugar Lump Tooltip ON'], desc: 'Shows the current Sugar Lump type in Sugar lump tooltip.', toggle: true};
+CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura OFF', 'Extra Dragon Aura ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
 
 // Statistics
 CM.ConfigData.Stats = {type: 'bool', group: 'Statistics', label: ['Statistics OFF', 'Statistics ON'], desc: 'Extra Cookie Monster statistics!', toggle: true};

--- a/src/Data.js
+++ b/src/Data.js
@@ -162,7 +162,7 @@ CM.ConfigData.ToolWarnPos = {type: 'bool', group: 'Tooltip', label: ['Tooltip Wa
 CM.ConfigData.TooltipGrim = {type: 'bool', group: 'Tooltip', label: ['Grimoire Tooltip Information OFF', 'Grimoire Tooltip Information ON'], desc: 'Extra information in tooltip for grimoire', toggle: true};
 CM.ConfigData.ToolWrink = {type: 'bool', group: 'Tooltip', label: ['Wrinkler Tooltip OFF', 'Wrinkler Tooltip ON'], desc: 'Shows the amount of cookies a wrinkler will give when popping it', toggle: true};
 CM.ConfigData.TooltipLump = {type: 'bool', group: 'Tooltip', label: ['Sugar Lump Tooltip OFF', 'Sugar Lump Tooltip ON'], desc: 'Shows the current Sugar Lump type in Sugar lump tooltip.', toggle: true};
-CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura OFF', 'Extra Dragon Aura ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
+CM.ConfigData.DragonAuraInfo = {type: 'bool', group: 'Tooltip', label: ['Extra Dragon Aura Info OFF', 'Extra Dragon Aura Info ON'], desc: 'Shows information about changes in CPS and costs in the dragon aura interface.', toggle: true};
 
 // Statistics
 CM.ConfigData.Stats = {type: 'bool', group: 'Statistics', label: ['Statistics OFF', 'Statistics ON'], desc: 'Extra Cookie Monster statistics!', toggle: true};

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1767,6 +1767,17 @@ CM.Disp.UpdateWrinklerTooltip = function() {
 }
 
 /********
+ * Section: Functions related to the dragon aura interface */
+
+CM.Disp.AddAuraInfo = function() {
+	if (CM.Config.DragonAuraInfo == 1) {
+		console.log("Yes!")
+	} else {
+		console.log("No!")
+	}
+}
+
+/********
  * Section: General functions related to the Options/Stats pages
 
 /**

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1768,24 +1768,32 @@ CM.Disp.UpdateWrinklerTooltip = function() {
 
 /********
  * Section: Functions related to the dragon aura interface */
+
 /**
  * This functions adds the two extra lines about CPS and time to recover to the aura picker infoscreen
- * This adds information about CPS differences and costs to the aura choosing interface
+ * It is called by Game.DescribeDragonAura() after CM.ReplaceNative()
  * @param	{number}	aura	The number of the aura currently selected by the mouse/user
  */
-CM.Disp.AddAuraInfo = function() {
+CM.Disp.AddAuraInfo = function(aura) {
 	if (CM.Config.DragonAuraInfo == 1) {
-		console.log("called")
-		var bonusCPS = "TESTCPS";
-		var bonusCPSPercentage = "TESTCPS%";
-		var timeToRecover = "TESTTIME";
-		l('dragonAuraInfo').style.minHeight = "90px"
+		var [bonusCPS, priceOfChange] = CM.Sim.CalculateChangeAura(aura);
+		var timeToRecover = CM.Disp.FormatTime(priceOfChange / (bonusCPS + Game.cookiesPs));
+		var bonusCPSPercentage = CM.Disp.Beautify(bonusCPS / Game.cookiesPs);
+		bonusCPS = CM.Disp.Beautify(bonusCPS);
+
+		l('dragonAuraInfo').style.minHeight = "60px"
+		l('dragonAuraInfo').style.margin = "8px"
 		l('dragonAuraInfo').appendChild(document.createElement("div")).className = "line"
 		var div = document.createElement("div");
 		div.style.minWidth = "200px";
 		div.style.textAlign = "center";
-		div.textContent = "Picking this aura will change CPS by " + bonusCPS + " (" + bonusCPSPercentage + "% of current cps). It will take " + timeToRecover + " to recover the cost.";
+		div.textContent = "Picking this aura will change CPS by " + bonusCPS + " (" + bonusCPSPercentage + "% of current CPS).";
 		l('dragonAuraInfo').appendChild(div);
+		var div2 = document.createElement("div");
+		div2.style.minWidth = "200px";
+		div2.style.textAlign = "center";
+		div2.textContent = "It will take " + timeToRecover + " to recover the cost.";
+		l('dragonAuraInfo').appendChild(div2);
 	}
 }
 

--- a/src/Disp.js
+++ b/src/Disp.js
@@ -1768,12 +1768,24 @@ CM.Disp.UpdateWrinklerTooltip = function() {
 
 /********
  * Section: Functions related to the dragon aura interface */
-
+/**
+ * This functions adds the two extra lines about CPS and time to recover to the aura picker infoscreen
+ * This adds information about CPS differences and costs to the aura choosing interface
+ * @param	{number}	aura	The number of the aura currently selected by the mouse/user
+ */
 CM.Disp.AddAuraInfo = function() {
 	if (CM.Config.DragonAuraInfo == 1) {
-		console.log("Yes!")
-	} else {
-		console.log("No!")
+		console.log("called")
+		var bonusCPS = "TESTCPS";
+		var bonusCPSPercentage = "TESTCPS%";
+		var timeToRecover = "TESTTIME";
+		l('dragonAuraInfo').style.minHeight = "90px"
+		l('dragonAuraInfo').appendChild(document.createElement("div")).className = "line"
+		var div = document.createElement("div");
+		div.style.minWidth = "200px";
+		div.style.textAlign = "center";
+		div.textContent = "Picking this aura will change CPS by " + bonusCPS + " (" + bonusCPSPercentage + "% of current cps). It will take " + timeToRecover + " to recover the cost.";
+		l('dragonAuraInfo').appendChild(div);
 	}
 }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -58,6 +58,18 @@ CM.ReplaceNative = function() {
 		Game.CalculateGains();
 	}
 
+	
+	CM.Backup.DescribeDragonAura = Game.DescribeDragonAura;
+	/**
+	 * This functions adds the function CM.Disp.AddAuraInfo() to Game.DescribeDragonAura()
+	 * This adds information about CPS differences and costs to the aura choosing interface
+	 * @param	{number}	aura	The number of the aura current selected by the mouse/user
+	 */
+	Game.DescribeDragonAura = function(aura) {
+		CM.Backup.DescribeDragonAura(aura);
+		CM.Disp.AddAuraInfo();
+	}
+
 	CM.Backup.UpdateMenu = Game.UpdateMenu;
 	Game.UpdateMenu = function() {
 		if (typeof jscolor.picker === 'undefined' || typeof jscolor.picker.owner === 'undefined') {
@@ -531,6 +543,7 @@ CM.ConfigDefault = {
 	TooltipGrim:1, 
 	ToolWrink: 1, 
 	TooltipLump: 1,
+	DragonAuraInfo: 1,
 	Stats: 1, 
 	MissingUpgrades: 0,
 	UpStats: 1, 

--- a/src/Main.js
+++ b/src/Main.js
@@ -63,11 +63,11 @@ CM.ReplaceNative = function() {
 	/**
 	 * This functions adds the function CM.Disp.AddAuraInfo() to Game.DescribeDragonAura()
 	 * This adds information about CPS differences and costs to the aura choosing interface
-	 * @param	{number}	aura	The number of the aura current selected by the mouse/user
+	 * @param	{number}	aura	The number of the aura currently selected by the mouse/user
 	 */
 	Game.DescribeDragonAura = function(aura) {
 		CM.Backup.DescribeDragonAura(aura);
-		CM.Disp.AddAuraInfo();
+		CM.Disp.AddAuraInfo(aura);
 	}
 
 	CM.Backup.UpdateMenu = Game.UpdateMenu;

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -142,7 +142,8 @@ CM.Sim.getCPSBuffMult = function() {
 	return mult;
 }
 
-/* Constructs an object with the static properties of a building,
+/**
+ * Constructs an object with the static properties of a building,
  * but with a 'cps' method changed to use 'CM.Sim.Has' instead of 'Game.Has'
  * (and similar to 'hasAura', 'Objects', 'GetTieredCpsMult' and 'auraMult').
  *
@@ -166,7 +167,8 @@ CM.Sim.InitialBuildingData = function(buildingName) {
 	return you;
 }
 
-/* Similar to the previous function, but for upgrades.
+/**
+ *  Similar to the previous function, but for upgrades.
  * Note: currently no static data is used by Cookie Monster,
  * so this function just returns an empty object.
  */
@@ -178,7 +180,8 @@ CM.Sim.InitUpgrade = function(upgradeName) {
 	return you;
 }
 
-/* Similar to the previous function, but for achievements.
+/**
+ * Similar to the previous function, but for achievements.
  * Note: currently no static data is used by Cookie Monster,
  * so this function just returns an empty object.
  */

--- a/src/Sim.js
+++ b/src/Sim.js
@@ -628,6 +628,12 @@ CM.Sim.BuyUpgrades = function() {
 	}
 }
 
+/**
+ * This functions calculates the cps and cost of changing a Dragon Aura
+ * It is called by CM.Disp.AddAuraInfo()
+ * @param	{number}			aura										The number of the aura currently selected by the mouse/user
+ * @returns {[number, number]} 	[CM.Sim.cookiesPs - Game.cookiesPs, price]	The bonus cps and the price of the change
+ */
 CM.Sim.CalculateChangeAura = function(aura) {
 	CM.Sim.CopyData();
 


### PR DESCRIPTION
The display now shows the change in cps, the change in percentage of cps and the time to recover the cost of changing the aura.

This closes #185 