### PR TITLE
Add cookieclicker.ee to supported userscript sites

### DIFF
--- a/CookieMonster.user.js
+++ b/CookieMonster.user.js
@@ -1,6 +1,7 @@
 // ==UserScript==
 // @name Cookie Monster
 // @include /https?://orteil.dashnet.org/cookieclicker/
+// @include /https?://cookieclicker.ee/
 // ==/UserScript==
 
 const readyCheck = setInterval(() => {


### PR DESCRIPTION
Adds the [cookieclicker.ee](https://cookieclicker.ee) site as one of the supported sites for the userscript.

This is effectively the same site as [orteil.dashnet.org/cookieclicker](https://orteil.dashnet.org/cookieclicker/), and the bookmark option already works on that site