### PR TITLE
<0% formatting

### DIFF
--- a/src/Disp/InfoBars/TimerBar.js
+++ b/src/Disp/InfoBars/TimerBar.js
@@ -133,7 +133,7 @@ export function UpdateTimerBar() {
       updateChanceTotal(chanceToSpawn);
       l('CMTimerBarGCTime').textContent = `${Math.ceil(
         (Game.shimmerTypes.golden.maxTime - Game.shimmerTypes.golden.time) / Game.fps,
-      )} ${getChanceFinal() < 0.01 ? '<' : ''}${getChanceFinal().toLocaleString('en', {
+      )} ${getChanceFinal() < 0.01 ? '<' : ''}${(getChanceFinal() + 0.01).toLocaleString('en', { // "<0%" makes no sense. Should be offset by 0.01 (1%).
         style: 'percent',
       })}`;
       numberOfTimers += 1;

--- a/src/Disp/InfoBars/TimerBar.js
+++ b/src/Disp/InfoBars/TimerBar.js
@@ -133,7 +133,7 @@ export function UpdateTimerBar() {
       updateChanceTotal(chanceToSpawn);
       l('CMTimerBarGCTime').textContent = `${Math.ceil(
         (Game.shimmerTypes.golden.maxTime - Game.shimmerTypes.golden.time) / Game.fps,
-      )} ${getChanceFinal() < 0.01 ? '<' : ''}${(getChanceFinal() + 0.01).toLocaleString('en', { // "<0%" makes no sense. Should be offset by 0.01 (1%).
+      )} ${getChanceFinal() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {  // "<0%" makes no sense. Should be offset by 0.01 (1%).
         style: 'percent',
       })}`;
       numberOfTimers += 1;
@@ -177,7 +177,7 @@ export function UpdateTimerBar() {
       updateChanceTotalDeer(chanceToSpawn);
       l('CMTimerBarRenTime').textContent = `${Math.ceil(
         (Game.shimmerTypes.reindeer.maxTime - Game.shimmerTypes.reindeer.time) / Game.fps,
-      )} ${getChanceFinalDeer() < 0.01 ? '<' : ''}${getChanceFinalDeer().toLocaleString('en', {
+      )} ${getChanceFinalDeer() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {  // "<0%" makes no sense. Should be offset by 0.01 (1%).
         style: 'percent',
       })}`;
       numberOfTimers += 1;

--- a/src/Disp/InfoBars/TimerBar.js
+++ b/src/Disp/InfoBars/TimerBar.js
@@ -133,7 +133,8 @@ export function UpdateTimerBar() {
       updateChanceTotal(chanceToSpawn);
       l('CMTimerBarGCTime').textContent = `${Math.ceil(
         (Game.shimmerTypes.golden.maxTime - Game.shimmerTypes.golden.time) / Game.fps,
-      )} ${getChanceFinal() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {  // "<0%" makes no sense. Should be offset by 0.01 (1%).
+      )} ${getChanceFinal() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {
+        // "<0%" makes no sense. Should be offset by 0.01 (1%).
         style: 'percent',
       })}`;
       numberOfTimers += 1;
@@ -177,7 +178,8 @@ export function UpdateTimerBar() {
       updateChanceTotalDeer(chanceToSpawn);
       l('CMTimerBarRenTime').textContent = `${Math.ceil(
         (Game.shimmerTypes.reindeer.maxTime - Game.shimmerTypes.reindeer.time) / Game.fps,
-      )} ${getChanceFinalDeer() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {  // "<0%" makes no sense. Should be offset by 0.01 (1%).
+      )} ${getChanceFinalDeer() < 0.01 ? '<' : ''}${(0.01).toLocaleString('en', {
+        // "<0%" makes no sense. Should be offset by 0.01 (1%).
         style: 'percent',
       })}`;
       numberOfTimers += 1;


### PR DESCRIPTION
Should be rather self-explanatory. Attempting to prevent the situation where "<0%" is shown since less than 0 percent should not be possible. There was also no reason to call getChanceFinal() or getChanceFinalDeer() in the response since the if condition already determined it was less than 1% so it should be okay to simply write "<1%".